### PR TITLE
Docs: Fix accidental relative URL to be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This code will cache responses from LLMS by default in `$HOME/.paperqa/llm_cache
 
 ### Can I use different LLMs?
 
-Yes, you can use any LLMs from [langchain](langchain.readthedocs.io/) by passing the `llm` argument to the `Docs` class. You can use different LLMs for summarization and for question answering too.
+Yes, you can use any LLMs from [langchain](https://langchain.readthedocs.io/) by passing the `llm` argument to the `Docs` class. You can use different LLMs for summarization and for question answering too.
 
 ### Where do the documents come from?
 


### PR DESCRIPTION
It's the smallest of changes but it may help somebody. Previously, clicking on the link yielded a 404 on github.com owing to the relative nature of the link.