### PR TITLE
Fixing the format of (Citation1, Citation2, Citation3)

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -356,7 +356,7 @@ class Docs:
         for key, citation, summary, text in citations:
             # do check for whole key (so we don't catch Callahan2019a with Callahan2019)
             skey = key.split(" ")[0]
-            if skey + " " in answer_text or skey + ")" in answer_text:
+            if skey + " " in answer_text or skey + ")" or skey + "," in answer_text:
                 bib[skey] = citation
                 passages[key] = text
         bib_str = "\n\n".join(


### PR DESCRIPTION
This adds support for recognising the citations in the answer in the format of 

(Citation1, Citation2, Citation3)

Currently, only Citation3 would be recognised in this citation. 