### PR TITLE
Integrate Zotero

### DIFF
--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -1,3 +1,2 @@
-from . import contrib
 from .docs import Docs, maybe_is_text, Answer
 from .version import __version__

--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -1,2 +1,3 @@
 from .docs import Docs, maybe_is_text, Answer
 from .version import __version__
+from . import contrib

--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -1,3 +1,3 @@
+from . import contrib
 from .docs import Docs, maybe_is_text, Answer
 from .version import __version__
-from . import contrib

--- a/paperqa/contrib/__init__.py
+++ b/paperqa/contrib/__init__.py
@@ -1,1 +1,1 @@
-from . import zotero
+from .zotero import QAZotero

--- a/paperqa/contrib/__init__.py
+++ b/paperqa/contrib/__init__.py
@@ -1,1 +1,1 @@
-from .zotero import ZoteroQA
+from .zotero import ZoteroDB

--- a/paperqa/contrib/__init__.py
+++ b/paperqa/contrib/__init__.py
@@ -1,1 +1,1 @@
-from .zotero import QAZotero
+from .zotero import ZoteroQA

--- a/paperqa/contrib/__init__.py
+++ b/paperqa/contrib/__init__.py
@@ -1,0 +1,1 @@
+from . import zotero

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -1,6 +1,6 @@
 # This file gets PDF files from the user's Zotero library
 import os
-from typing import Union
+from typing import Union, Optional
 from pathlib import Path
 import logging
 
@@ -28,9 +28,9 @@ class QAZotero(zotero.Zotero):
         self,
         *,
         library_type: str = "user",
-        library_id=None,
-        api_key=None,
-        storage=None,
+        library_id: Optional[str] = None,
+        api_key: Optional[str] = None,
+        storage: Optional[StrPath] = None,
         **kwargs,
     ):
         self.logger = logging.getLogger("QAZotero")
@@ -102,14 +102,14 @@ class QAZotero(zotero.Zotero):
 
     def gen_paperdb(
         self,
-        q=None,
-        qmode=None,
-        since=None,
-        tag=None,
-        sort=None,
-        direction=None,
-        limit=None,
-        start=None,
+        q: Optional[str] = None,
+        qmode: Optional[str] = None,
+        since: Optional[str] = None,
+        tag: Optional[str] = None,
+        sort: Optional[str] = None,
+        direction: Optional[str] = None,
+        limit: int = 25,
+        start: int = 0,
     ):
         """Given a search query, this converts the Zotero library to a `paperqa.docs.Docs` object.
 
@@ -157,19 +157,11 @@ class QAZotero(zotero.Zotero):
         if direction is not None:
             query_kwargs["direction"] = direction
 
-        # (We deal with start and limit manually)
-        if limit is None:
-            limit = 25
-
-        if start is None:
-            start = 0
-
         max_limit = 100
 
         items = []
         pdfs = []
         citations = []
-        keys = []
         num_remaining = limit - len(items)
 
         while num_remaining > 0:

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -6,9 +6,6 @@ import logging
 
 from pyzotero import zotero
 
-from ..docs import CACHE_PATH
-from .. import Docs
-
 StrPath = Union[str, Path]
 
 
@@ -62,6 +59,8 @@ class QAZotero(zotero.Zotero):
         self.logger.info(f"Using library ID: {library_id} with type: {library_type}.")
 
         if storage is None:
+            from ..docs import CACHE_PATH
+
             storage = CACHE_PATH.parent / "zotero"
 
         self.logger.info(f"Using cache location: {storage}")
@@ -192,6 +191,8 @@ class QAZotero(zotero.Zotero):
             num_remaining = limit - len(items)
 
         self.logger.info("Finished downloading papers. Now creating Docs object.")
+        from .. import Docs
+
         docs = Docs()
 
         for i in range(len(items)):

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -12,6 +12,16 @@ StrPath = Union[str, Path]
 
 
 class QAZotero(zotero.Zotero):
+    """An extension of pyzotero.zotero.Zotero to interface with paperqa.
+    
+    This class automatically reads in your `ZOTERO_USER_ID` and `ZOTERO_API_KEY`
+    from your environment variables. If you do not have these, see 
+    step 2 of https://github.com/urschrei/pyzotero#quickstart.
+    
+    This class will download PDFs from your Zotero library and store them in
+    `~/.paperqa/zotero` by default. To use this class, call the `gen_paperdb`
+    method, which returns a `paperqa.Docs` object.
+    """
     def __init__(
         self,
         *,

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -204,7 +204,7 @@ class QAZotero(zotero.Zotero):
 
         for i in range(len(items)):
             self.logger.info(f"|  Adding paper {citations[i]} to Docs.")
-            docs.add(path=pdfs[i], citation=citations[i], key=items[i]["key"])
+            docs.add(path=pdfs[i], key=citations[i])
 
         self.logger.info(f"Done.")
         return docs

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -21,7 +21,7 @@ class ZoteroPaper(_ZoteroPaper):
         return f'ZoteroPaper(\n    key = "{self.key}",\n    title = "{self.title}",\n    pdf = "{self.pdf}",\n    zotero_key = "{self.zotero_key}",\n    details = ...\n)'
 
 
-class ZoteroQA(zotero.Zotero):
+class ZoteroDB(zotero.Zotero):
     """An extension of pyzotero.zotero.Zotero to interface with paperqa.
 
     This class automatically reads in your `ZOTERO_USER_ID` and `ZOTERO_API_KEY`
@@ -29,7 +29,7 @@ class ZoteroQA(zotero.Zotero):
     step 2 of https://github.com/urschrei/pyzotero#quickstart.
 
     This class will download PDFs from your Zotero library and store them in
-    `~/.paperqa/zotero` by default. To use this class, call the `gen_paperdb`
+    `~/.paperqa/zotero` by default. To use this class, call the `iterate`
     method, which returns a `paperqa.Docs` object.
     """
 
@@ -42,7 +42,7 @@ class ZoteroQA(zotero.Zotero):
         storage: Optional[StrPath] = None,
         **kwargs,
     ):
-        self.logger = logging.getLogger("ZoteroQA")
+        self.logger = logging.getLogger("ZoteroDB")
 
         if library_id is None:
             self.logger.info(f"Attempting to get ZOTERO_USER_ID from `os.environ`...")
@@ -109,7 +109,7 @@ class ZoteroQA(zotero.Zotero):
 
         return pdf_path
 
-    def gen_paperdb(
+    def iterate(
         self,
         q: Optional[str] = None,
         qmode: Optional[str] = None,

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -6,6 +6,9 @@ import logging
 
 from pyzotero import zotero
 
+from ..docs import CACHE_PATH
+from .. import Docs
+
 StrPath = Union[str, Path]
 
 
@@ -59,8 +62,6 @@ class ZoteroQA(zotero.Zotero):
         self.logger.info(f"Using library ID: {library_id} with type: {library_type}.")
 
         if storage is None:
-            from ..docs import CACHE_PATH
-
             storage = CACHE_PATH.parent / "zotero"
 
         self.logger.info(f"Using cache location: {storage}")
@@ -191,7 +192,6 @@ class ZoteroQA(zotero.Zotero):
             num_remaining = limit - len(items)
 
         self.logger.info("Finished downloading papers. Now creating Docs object.")
-        from .. import Docs
 
         docs = Docs()
 

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -9,7 +9,7 @@ from pyzotero import zotero
 StrPath = Union[str, Path]
 
 
-class QAZotero(zotero.Zotero):
+class ZoteroQA(zotero.Zotero):
     """An extension of pyzotero.zotero.Zotero to interface with paperqa.
 
     This class automatically reads in your `ZOTERO_USER_ID` and `ZOTERO_API_KEY`
@@ -30,7 +30,7 @@ class QAZotero(zotero.Zotero):
         storage: Optional[StrPath] = None,
         **kwargs,
     ):
-        self.logger = logging.getLogger("QAZotero")
+        self.logger = logging.getLogger("ZoteroQA")
 
         if library_id is None:
             self.logger.info(f"Attempting to get ZOTERO_USER_ID from `os.environ`...")

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -2,7 +2,7 @@
 import os
 from typing import Union
 from pathlib import Path
-from logging import getLogger
+import logging
 
 from pyzotero import zotero
 
@@ -32,7 +32,8 @@ class QAZotero(zotero.Zotero):
         storage=None,
         **kwargs,
     ):
-        self.logger = getLogger("paperqa.contrib.QAZotero")
+        self.logger = logging.getLogger("QAZotero")
+
         if library_id is None:
             self.logger.info(f"Attempting to get ZOTERO_USER_ID from `os.environ`...")
             if "ZOTERO_USER_ID" not in os.environ:
@@ -222,9 +223,14 @@ def _get_citation_key(item: dict) -> str:
 
     last_name = item["data"]["creators"][0]["lastName"]
     short_title = "".join(item["data"]["title"].split(" ")[:3])
-    year = item["data"]["date"]
+    date = item["data"]["date"]
 
-    return f"{last_name}{short_title}{year}_{item['key']}"
+    # Delete non-alphanumeric characters:
+    short_title = "".join([c for c in short_title if c.isalnum()])
+    last_name = "".join([c for c in last_name if c.isalnum()])
+    date = "".join([c for c in date if c.isalnum()])
+
+    return f"{last_name}_{short_title}_{date}_{item['key']}".replace(" ", "")
 
 
 def _extract_pdf_key(item: dict) -> str:

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -1,95 +1,103 @@
 # This file gets PDF files from the user's Zotero library
 import os
-import warnings
-from typing import Optional, Union, List
+from typing import Union
 from pathlib import Path
-from functools import lru_cache
 
 from pyzotero import zotero
+
+from ..docs import CACHE_PATH
 
 StrPath = Union[str, Path]
 
 
-def default_library(library_type: str = "user") -> zotero.Zotero:
-    """Returns a Zotero library object for the user's default library."""
+class QAZotero(zotero.Zotero):
+    def __init__(
+        self, *, library_type: str = "user", library_id=None, api_key=None, storage=None, **kwargs
+    ):
+        if library_id is None:
+            if "ZOTERO_USER_ID" not in os.environ:
+                raise ValueError(
+                    "ZOTERO_USER_ID not set. Please navigate to"
+                    " https://www.zotero.org/settings/keys and get your user ID"
+                    " from the text 'Your userID for use in API calls is [XXXXXX]'."
+                    " Then, set the environment variable ZOTERO_USER_ID to this value."
+                )
+            else:
+                library_id = os.environ["ZOTERO_USER_ID"]
 
-    if "ZOTERO_USER_ID" not in os.environ:
-        raise ValueError(
-            "ZOTERO_USER_ID not set. Please navigate to"
-            " https://www.zotero.org/settings/keys and get your user ID"
-            " from the text 'Your userID for use in API calls is [XXXXXX]'."
-            " Then, set the environment variable ZOTERO_USER_ID to this value."
+        if api_key is None:
+            if "ZOTERO_API_KEY" not in os.environ:
+                raise ValueError(
+                    "ZOTERO_API_KEY not set. Please navigate to"
+                    " https://www.zotero.org/settings/keys and create a new API key"
+                    " with access to your library."
+                    " Then, set the environment variable ZOTERO_API_KEY to this value."
+                )
+            else:
+                api_key = os.environ["ZOTERO_API_KEY"]
+
+        if storage is None:
+            storage = CACHE_PATH.parent / "zotero"
+        
+        self.storage = storage
+
+        super().__init__(
+            library_type=library_type, library_id=library_id, api_key=api_key, **kwargs
         )
 
-    if "ZOTERO_API_KEY" not in os.environ:
-        raise ValueError(
-            "ZOTERO_API_KEY not set. Please navigate to"
-            " https://www.zotero.org/settings/keys and create a new API key"
-            " with access to your library."
-            " Then, set the environment variable ZOTERO_API_KEY to this value."
-        )
+    def get_pdf(self, item: dict) -> Union[Path, None]:
+        """Gets a filename for a given Zotero key for a PDF.
 
-    return zotero.Zotero(
-        os.environ["ZOTERO_USER_ID"],
-        library_type,
-        os.environ["ZOTERO_API_KEY"],
-    )
+        If the PDF is not found locally, the PDF will be downloaded to a local file at the correct key.
+        If no PDF exists for the file, None is returned.
 
+        Parameters
+        ----------
+        item : dict
+            An item from `pyzotero`. Should have a `key` field, and also have an entry
+            `links->attachment->attachmentType == application/pdf`.
+        """
+        if type(item) != dict:
+            raise TypeError("Pass the full item of the paper. The item must be a dict.")
 
-@lru_cache(maxsize=1)
-def cached_walk(root: StrPath) -> List:
-    return list(os.walk(root))
+        pdf_key = _extract_pdf_key(item)
 
+        if pdf_key is None:
+            return None
 
-def get_pdf(item: dict, *, storage: Optional[StrPath] = None) -> Union[Path, None]:
-    """Gets a PDF filename for a given Zotero key.
+        pdf_path = self.storage / (pdf_key + ".pdf")
 
-    If storage is None, or if the PDF is not found locally, the PDF will be downloaded to a local file.
-    """
-    key = item["key"]
-    has_pdf = (
-        "links" in item
-        and "attachment" in item["links"]
-        and (
-            (
-                "attachmentType" in item["links"]["attachment"]
-                and item["links"]["attachment"]["attachmentType"] == "application/pdf"
-            )
-            or any(
-                [
-                    "attachmentType" in l and l["attachmentType"] == "application/pdf"
-                    for l in item["links"]["attachment"]
-                ]
-            )
-        )
-    )
+        if not pdf_path.exists():
+            pdf_path.parent.mkdir(parents=True, exist_ok=True)
+            self.dump(pdf_key, pdf_path)
 
-    if not has_pdf:
+        return pdf_path
+        
+
+def _extract_pdf_key(item: dict) -> str:
+    """Extract the PDF key from a Zotero item."""
+
+    if "links" not in item:
         return None
 
-    # Replace with home directory:
-    if storage is not None:
-        raise NotImplementedError("Storage not implemented yet, due to inconsistencies in keys between local and remote.")
-        # storage = Path(os.path.expanduser(storage))
-        # if has_pdf:
-        #     with open("test.txt", "w") as f:
-        #         for root, dirs, files in cached_walk(storage):
-        #             root = Path(root)
-        #             for dir in dirs:
-        #                 print(dir, file=f)
-        #                 if dir == key:
-        #                     print("HERE")
-        #                     # Find all PDFs in this directory:
-        #                     pdfs = [
-        #                         root / dir / f
-        #                         for f in os.listdir(root / dir)
-        #                         if f.endswith(".pdf")
-        #                     ]
-        #                     if len(pdfs) > 0:
-        #                         if len(pdfs) > 1:
-        #                             warnings.warn(
-        #                                 f"Found multiple PDFs for item {key}. Picking the first."
-        #                             )
-        #                         return pdfs[0]
+    if "attachment" not in item["links"]:
+        return None
 
-    # We did not find the PDF locally. Thus, we need to download it.
+    attachments = item["links"]["attachment"]
+
+    if type(attachments) != dict:
+        # Find first attachment with attachmentType == application/pdf:
+        for attachment in attachments:
+            # TODO: This assumes there's only one PDF attachment.
+            if attachment["attachmentType"] == "application/pdf":
+                break
+    else:
+        attachment = attachments
+
+    if "attachmentType" not in attachment:
+        return None
+
+    if attachment["attachmentType"] != "application/pdf":
+        return None
+
+    return attachment["href"].split("/")[-1]

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -14,15 +14,16 @@ StrPath = Union[str, Path]
 
 class QAZotero(zotero.Zotero):
     """An extension of pyzotero.zotero.Zotero to interface with paperqa.
-    
+
     This class automatically reads in your `ZOTERO_USER_ID` and `ZOTERO_API_KEY`
-    from your environment variables. If you do not have these, see 
+    from your environment variables. If you do not have these, see
     step 2 of https://github.com/urschrei/pyzotero#quickstart.
-    
+
     This class will download PDFs from your Zotero library and store them in
     `~/.paperqa/zotero` by default. To use this class, call the `gen_paperdb`
     method, which returns a `paperqa.Docs` object.
     """
+
     def __init__(
         self,
         *,
@@ -174,16 +175,16 @@ class QAZotero(zotero.Zotero):
         while num_remaining > 0:
             cur_limit = min(max_limit, num_remaining)
             self.logger.info(f"Downloading new batch of up to {cur_limit} papers.")
-            _items = self.top(
-                **query_kwargs, limit=cur_limit, start=start
-            )
+            _items = self.top(**query_kwargs, limit=cur_limit, start=start)
+            if len(_items) == 0:
+                break
             start += cur_limit
             self.logger.info(f"Downloading PDFs.")
             _pdfs = [self.get_pdf(item) for item in _items]
 
             # Filter:
             new_items = []
-            for (item, pdf) in zip(_items, _pdfs):
+            for item, pdf in zip(_items, _pdfs):
                 no_pdf = item is None or pdf is None
                 is_duplicate = pdf in pdfs
 
@@ -193,7 +194,6 @@ class QAZotero(zotero.Zotero):
                 new_items.append(item)
                 items.append(item)
                 pdfs.append(pdf)
-
 
             citations.extend([_get_citation_key(item) for item in new_items])
 

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -176,6 +176,7 @@ class QAZotero(zotero.Zotero):
             _items = self.top(
                 **query_kwargs, limit=cur_limit, start=start
             )
+            start += cur_limit
             self.logger.info(f"Downloading PDFs.")
             _pdfs = [self.get_pdf(item) for item in _items]
 
@@ -196,7 +197,6 @@ class QAZotero(zotero.Zotero):
             citations.extend([_get_citation_key(item) for item in new_items])
 
             num_remaining = limit - len(items)
-            start += len(new_items)
 
         self.logger.info("Finished downloading papers. Now creating Docs object.")
         docs = Docs()

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -1,0 +1,95 @@
+# This file gets PDF files from the user's Zotero library
+import os
+import warnings
+from typing import Optional, Union, List
+from pathlib import Path
+from functools import lru_cache
+
+from pyzotero import zotero
+
+StrPath = Union[str, Path]
+
+
+def default_library(library_type: str = "user") -> zotero.Zotero:
+    """Returns a Zotero library object for the user's default library."""
+
+    if "ZOTERO_USER_ID" not in os.environ:
+        raise ValueError(
+            "ZOTERO_USER_ID not set. Please navigate to"
+            " https://www.zotero.org/settings/keys and get your user ID"
+            " from the text 'Your userID for use in API calls is [XXXXXX]'."
+            " Then, set the environment variable ZOTERO_USER_ID to this value."
+        )
+
+    if "ZOTERO_API_KEY" not in os.environ:
+        raise ValueError(
+            "ZOTERO_API_KEY not set. Please navigate to"
+            " https://www.zotero.org/settings/keys and create a new API key"
+            " with access to your library."
+            " Then, set the environment variable ZOTERO_API_KEY to this value."
+        )
+
+    return zotero.Zotero(
+        os.environ["ZOTERO_USER_ID"],
+        library_type,
+        os.environ["ZOTERO_API_KEY"],
+    )
+
+
+@lru_cache(maxsize=1)
+def cached_walk(root: StrPath) -> List:
+    return list(os.walk(root))
+
+
+def get_pdf(item: dict, *, storage: Optional[StrPath] = None) -> Union[Path, None]:
+    """Gets a PDF filename for a given Zotero key.
+
+    If storage is None, or if the PDF is not found locally, the PDF will be downloaded to a local file.
+    """
+    key = item["key"]
+    has_pdf = (
+        "links" in item
+        and "attachment" in item["links"]
+        and (
+            (
+                "attachmentType" in item["links"]["attachment"]
+                and item["links"]["attachment"]["attachmentType"] == "application/pdf"
+            )
+            or any(
+                [
+                    "attachmentType" in l and l["attachmentType"] == "application/pdf"
+                    for l in item["links"]["attachment"]
+                ]
+            )
+        )
+    )
+
+    if not has_pdf:
+        return None
+
+    # Replace with home directory:
+    if storage is not None:
+        raise NotImplementedError("Storage not implemented yet, due to inconsistencies in keys between local and remote.")
+        # storage = Path(os.path.expanduser(storage))
+        # if has_pdf:
+        #     with open("test.txt", "w") as f:
+        #         for root, dirs, files in cached_walk(storage):
+        #             root = Path(root)
+        #             for dir in dirs:
+        #                 print(dir, file=f)
+        #                 if dir == key:
+        #                     print("HERE")
+        #                     # Find all PDFs in this directory:
+        #                     pdfs = [
+        #                         root / dir / f
+        #                         for f in os.listdir(root / dir)
+        #                         if f.endswith(".pdf")
+        #                     ]
+        #                     if len(pdfs) > 0:
+        #                         if len(pdfs) > 1:
+        #                             warnings.warn(
+        #                                 f"Found multiple PDFs for item {key}. Picking the first."
+        #                             )
+        #                         return pdfs[0]
+
+    # We did not find the PDF locally. Thus, we need to download it.

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -1,5 +1,6 @@
 from .utils import maybe_is_code
 from html2text import html2text
+from pathlib import Path
 
 from langchain.text_splitter import TokenTextSplitter
 
@@ -100,6 +101,8 @@ def parse_code_txt(path, citation, key, chunk_chars=2000, overlap=50):
 
 def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=False):
     """Parse a document into chunks."""
+    if isinstance(path, Path):
+        path = str(path)
     if path.endswith(".pdf"):
         return parse_pdf(path, citation, key, chunk_chars, overlap)
     elif path.endswith(".txt"):

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "PyCryptodome",
         "html2text",
         "tiktoken",
+        "pyzotero",
     ],
     test_suite="tests",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="white.d.andrew@gmail.com",
     url="https://github.com/whitead/paper-qa",
     license="MIT",
-    packages=["paperqa"],
+    packages=["paperqa", "paperqa.contrib"],
     install_requires=[
         "pypdf",
         "langchain>=0.0.98",


### PR DESCRIPTION
Zotero is perhaps the most popular tool in academia for storing a database of citations/PDFs/notes of research papers, so it seems like it would be very useful if `paper-qa` could directly search a Zotero database.

This PR does the following:

1. Creates the `paperqa.contrib` module, to hold various plugins/interfaces in a separate module.
2. Creates the `paperqa.contrib.ZoteroDB` class to download PDFs and citation keys from a user's Zotero library (or a specific query of that Zotero library), and generate a `Docs` object from them.
3. All PDFs downloaded by this `ZoteroDB` class are by default cached into `~/.paperqa/zotero/{KEY}.pdf`.

---

Here's how this works: if you set `ZOTERO_USER_ID` and `ZOTERO_API_KEY` in your environment[^1], all you have to do is initialize the ZoteroDB object:

```python
from paperqa.contrib import ZoteroDB
zotero = ZoteroDB()
```

and it will now be set up to query from a user's zotero library and download PDFs.

This class inherits from [`pyzotero.zotero.Zotero`](https://github.com/urschrei/pyzotero). This parent class has a bunch of different functionality to query a Zotero library - much of that is inherited. This means you can do things like:

```python
zotero.top(q="Large Language Model", limit=10)
```

to view the top 10 hits from your Zotero library which contain "Large Language Models" in the title. More search syntax given [here](https://pyzotero.readthedocs.io/en/latest/?badge=latest#zotero.Zotero.add_parameters).

You can create a `Docs` object with the same syntax:

```python
docs = Docs()

for paper in zotero.iterate(q="Transformer", qmode="everything", sort="date", direction="desc", limit=20):
    docs.add(paper.pdf)
```

This function will lazily query the Zotero database (which is in the cloud) and find the first 20 papers, sorted by date in descending order, which have "Transformer" anywhere in the title/abstract (or full text, if the user has it) of the paper. It will lazily download 20 PDFs of those papers directly as saved inside the Zotero database (rather than needing to query an external service). If any paper doesn't have a PDF, it will get the next paper, until it reaches 20.

It will then put them all into a `docs` object for further research.

(You could also download the entire zotero library with `zot.gen_paperdb(limit=100000)`).

Let me know what you think! The API was a first draft so I am happy to tweak the names.


[^1]: See https://pyzotero.readthedocs.io/en/latest/?badge=latest#getting-started-short-version for getting these variables.

---

- Edit: Changed to `ZoteroQA` as the class name.
- Edit: Changed to `ZoteroDB`, and `iterate`. Also made `iterate` iterate over papers lazily, rather than download all at once.