### PR TITLE
Cache document parsing

### DIFF
--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 from pyzotero import zotero
 
-from ..docs import CACHE_PATH
+from ..paths import CACHE_PATH
 
 StrPath = Union[str, Path]
 

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -4,6 +4,7 @@ import os
 import os
 from pathlib import Path
 import re
+from .paths import CACHE_PATH
 from .utils import maybe_is_text, maybe_is_truncated
 from .qaprompts import (
     summary_prompt,
@@ -24,7 +25,6 @@ from langchain.cache import SQLiteCache
 import langchain
 from datetime import datetime
 
-CACHE_PATH = Path.home() / ".paperqa" / "llm_cache.db"
 os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
 langchain.llm_cache = SQLiteCache(CACHE_PATH)
 

--- a/paperqa/paths.py
+++ b/paperqa/paths.py
@@ -1,3 +1,4 @@
 from pathlib import Path
 
 CACHE_PATH = Path.home() / ".paperqa" / "llm_cache.db"
+OCR_CACHE_PATH = CACHE_PATH.parent / "ocr_cache.db"

--- a/paperqa/paths.py
+++ b/paperqa/paths.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+CACHE_PATH = Path.home() / ".paperqa" / "llm_cache.db"

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -118,20 +118,27 @@ def parse_code_txt(path, citation, key, chunk_chars=2000, overlap=50):
 
 
 def _serialize_s(obj):
+    """Convert a json-like object to a string"""
+    # We sort the keys to ensure
+    # that the same object always gets serialized to the same string.
     return json.dumps(obj, sort_keys=True, ensure_ascii=False)
+
+
+def _deserialize_s(obj):
+    """The inverse of _serialize_s"""
+    return json.loads(obj)
 
 
 def _serialize(obj):
     # llmchain wants a list of "Generation" objects, so we simply
-    # stick this regular text into it. We sort the keys to ensure
-    # that the same object always gets serialized to the same string.
+    # stick this regular text into it. 
     return [Generation(text=_serialize_s(obj))]
 
 
 def _deserialize(obj):
     # (The inverse of _serialize)
     try:
-        return json.loads(obj[0].text)
+        return _deserialize_s(obj[0].text)
     except json.JSONDecodeError:
         return None
 

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -161,6 +161,7 @@ def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=F
             chunk_chars=chunk_chars,
             overlap=overlap,
             disable_check=disable_check,
+            version=__version__,
         )
     )
     logger.debug(f"Looking up cache key for {path}")

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -136,12 +136,26 @@ def _deserialize(obj):
         return None
 
 
+def _filehash(path):
+    """Fast hash of a file - about 1ms per MB."""
+    bufsize = 65536
+    h = 0
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(bufsize)
+            if not data:
+                break
+            h = hash((h, data))
+
+    return h
+
+
 def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=False):
     logger = logging.getLogger(__name__)
     logger.debug(f"Creating cache key for {path}")
     cache_key = _serialize_s(
         dict(
-            path=str(path),
+            hash=str(_filehash(path)),
             citation=citation,
             key=key,
             chunk_chars=chunk_chars,

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -117,11 +117,15 @@ def parse_code_txt(path, citation, key, chunk_chars=2000, overlap=50):
     return splits, metadatas
 
 
+def _serialize_s(obj):
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False)
+
+
 def _serialize(obj):
     # llmchain wants a list of "Generation" objects, so we simply
     # stick this regular text into it. We sort the keys to ensure
     # that the same object always gets serialized to the same string.
-    return [Generation(text=json.dumps(obj, sort_keys=True, ensure_ascii=False))]
+    return [Generation(text=_serialize_s(obj))]
 
 
 def _deserialize(obj):
@@ -135,7 +139,7 @@ def _deserialize(obj):
 def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=False):
     logger = logging.getLogger(__name__)
     logger.debug(f"Creating cache key for {path}")
-    cache_key = json.dumps(
+    cache_key = _serialize_s(
         dict(
             path=str(path),
             citation=citation,
@@ -143,8 +147,7 @@ def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=F
             chunk_chars=chunk_chars,
             overlap=overlap,
             disable_check=disable_check,
-        ),
-        sort_keys=True,
+        )
     )
     logger.debug(f"Looking up cache key for {path}")
     cache_lookup = _get_ocr_cache().lookup(prompt=cache_key, llm_string="pdf")

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -1,8 +1,26 @@
-from .utils import maybe_is_code
+import os
+from .paths import OCR_CACHE_PATH
+from .version import __version__
 from html2text import html2text
 from pathlib import Path
+import json
+import logging
 
 from langchain.text_splitter import TokenTextSplitter
+from langchain.cache import SQLiteCache
+from langchain.schema import Generation
+
+OCR_CACHE = None
+
+
+def _get_ocr_cache() -> SQLiteCache:
+    """Used to lazily create the cache directory and cache object."""
+    global OCR_CACHE
+    if OCR_CACHE is None:
+        os.makedirs(os.path.dirname(OCR_CACHE_PATH), exist_ok=True)
+        OCR_CACHE = SQLiteCache(OCR_CACHE_PATH)
+    return OCR_CACHE
+
 
 TextSplitter = TokenTextSplitter
 
@@ -99,7 +117,76 @@ def parse_code_txt(path, citation, key, chunk_chars=2000, overlap=50):
     return splits, metadatas
 
 
+def _serialize(obj):
+    # llmchain wants a list of "Generation" objects, so we simply
+    # stick this regular text into it. We sort the keys to ensure
+    # that the same object always gets serialized to the same string.
+    return [Generation(text=json.dumps(obj, sort_keys=True, ensure_ascii=False))]
+
+
+def _deserialize(obj):
+    # (The inverse of _serialize)
+    try:
+        return json.loads(obj[0].text)
+    except json.JSONDecodeError:
+        return None
+
+
 def read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=False):
+    logger = logging.getLogger(__name__)
+    logger.debug(f"Creating cache key for {path}")
+    cache_key = json.dumps(
+        dict(
+            path=str(path),
+            citation=citation,
+            key=key,
+            chunk_chars=chunk_chars,
+            overlap=overlap,
+            disable_check=disable_check,
+        ),
+        sort_keys=True,
+    )
+    logger.debug(f"Looking up cache key for {path}")
+    cache_lookup = _get_ocr_cache().lookup(prompt=cache_key, llm_string="pdf")
+
+    out = None
+    successful_lookup = False
+    cache_exists = cache_lookup is not None
+    if cache_exists:
+        logger.debug(f"Found cache key for {path}")
+        out = _deserialize(cache_lookup)
+
+    successful_lookup = out is not None
+    if successful_lookup:
+        logger.debug(f"Succesfully loaded cache key for {path}")
+    elif cache_exists:
+        logger.debug(f"Failed to decode existing cache for {path}")
+
+    if out is None:
+        logger.debug(f"Did not load cache, so parsing {path}")
+
+        # The actual call:
+        out = _read_doc(
+            path=path,
+            citation=citation,
+            key=key,
+            chunk_chars=chunk_chars,
+            overlap=overlap,
+            disable_check=disable_check,
+        )
+
+        logger.debug(f"Done parsing document {path}")
+    if not successful_lookup:
+        logger.debug(f"Updating cache for {path}")
+        _get_ocr_cache().update(
+            prompt=cache_key,
+            llm_string="pdf",
+            return_val=_serialize(out),
+        )
+    return out
+
+
+def _read_doc(path, citation, key, chunk_chars=3000, overlap=100, disable_check=False):
     """Parse a document into chunks."""
     if isinstance(path, Path):
         path = str(path)


### PR DESCRIPTION
Hey @whitead,

This creates a cache for parsed documents, and gets half of #45 done. I just used the SQLite cache from langchain for simplicity, and deserialize/serialize results into the cache via `json.dumps`/`json.loads`. It helps quite a bit with speed of loading an previously-loaded PDF database, as the OCR doesn't need to re-run each time. The cache also supports other input filetypes, as the cache key is the hash of the file. The key also includes the paperqa version, so there shouldn't be compatibility issues with old caches.

I also refactored the paths into `paths.py`.

Let me know what you think!
Cheers,
Miles

---

- Edit 1: Uses the hash of the file as the cache key, rather than the pathname. This is much more robust.