### PR TITLE
Add `num_pages` attribute to `ZoteroPaper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ docs = paperqa.Docs()
 zotero = ZoteroDB(library_type="user")  # "group" if group library
 
 for item in zotero.iterate(limit=20):
+    if item.num_pages > 30:
+        continue  # skip long papers
     docs.add(item.pdf, key=item.key)
 ```
 

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -9,7 +9,7 @@ from pyzotero import zotero
 
 from ..paths import CACHE_PATH
 
-StrPath = Union[str, Path]
+from ..types import StrPath
 
 _ZoteroPaper = namedtuple(
     "ZoteroPaper", ["key", "title", "pdf", "zotero_key", "details"]

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -8,17 +8,17 @@ from collections import namedtuple
 from pyzotero import zotero
 
 from ..paths import CACHE_PATH
-
+from ..utils import count_pdf_pages
 from ..types import StrPath
 
 _ZoteroPaper = namedtuple(
-    "ZoteroPaper", ["key", "title", "pdf", "zotero_key", "details"]
+    "ZoteroPaper", ["key", "title", "pdf", "num_pages", "zotero_key", "details"]
 )
 
 
 class ZoteroPaper(_ZoteroPaper):
     def __repr__(self) -> str:
-        return f'ZoteroPaper(\n    key = "{self.key}",\n    title = "{self.title}",\n    pdf = "{self.pdf}",\n    zotero_key = "{self.zotero_key}",\n    details = ...\n)'
+        return f'ZoteroPaper(\n    key = "{self.key}",\n    title = "{self.title}",\n    pdf = "{self.pdf}",\n    num_pages = {self.num_pages},\n    zotero_key = "{self.zotero_key}",\n    details = ...\n)'
 
 
 class ZoteroDB(zotero.Zotero):
@@ -205,6 +205,7 @@ class ZoteroDB(zotero.Zotero):
                         key=_get_citation_key(item),
                         title=title,
                         pdf=pdf,
+                        num_pages=count_pdf_pages(pdf),
                         details=item,
                         zotero_key=item["key"],
                     )

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -11,14 +11,16 @@ from ..paths import CACHE_PATH
 from ..utils import count_pdf_pages
 from ..types import StrPath
 
-_ZoteroPaper = namedtuple(
+ZoteroPaper = namedtuple(
     "ZoteroPaper", ["key", "title", "pdf", "num_pages", "zotero_key", "details"]
 )
 
 
-class ZoteroPaper(_ZoteroPaper):
-    def __repr__(self) -> str:
-        return f'ZoteroPaper(\n    key = "{self.key}",\n    title = "{self.title}",\n    pdf = "{self.pdf}",\n    num_pages = {self.num_pages},\n    zotero_key = "{self.zotero_key}",\n    details = ...\n)'
+def _zotero_paper_repr(self) -> str:
+    return f'ZoteroPaper(\n    key = "{self.key}",\n    title = "{self.title}",\n    pdf = "{self.pdf}",\n    num_pages = {self.num_pages},\n    zotero_key = "{self.zotero_key}",\n    details = ...\n)'
+
+
+ZoteroPaper.__repr__ = _zotero_paper_repr
 
 
 class ZoteroDB(zotero.Zotero):

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -1,0 +1,4 @@
+from typing import Union
+from pathlib import Path
+
+StrPath = Union[str, Path]

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -1,5 +1,8 @@
 import math
 import string
+import pypdf
+
+from .types import StrPath
 
 
 def maybe_is_text(s, thresh=2.5):
@@ -50,3 +53,10 @@ def maybe_is_html(s):
     # check for html tags
     if "<body" in s or "<html" in s or "<div" in s:
         return True
+
+
+def count_pdf_pages(file_path: StrPath) -> int:
+    with open(file_path, "rb") as pdf_file:
+        pdf_reader = pypdf.PdfFileReader(pdf_file)
+        num_pages = pdf_reader.getNumPages()
+    return num_pages

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -57,6 +57,6 @@ def maybe_is_html(s):
 
 def count_pdf_pages(file_path: StrPath) -> int:
     with open(file_path, "rb") as pdf_file:
-        pdf_reader = pypdf.PdfFileReader(pdf_file)
-        num_pages = pdf_reader.getNumPages()
+        pdf_reader = pypdf.PdfReader(pdf_file)
+        num_pages = len(pdf_reader.pages)
     return num_pages


### PR DESCRIPTION
When doing an embedding of my entire zotero library, I realized some of the PDFs are from course notes/textbooks which number in the hundreds of pages. Thus I think it would be useful to add a `num_pages` attribute to the `ZoteroPaper` type which is generated by `ZoteroDB`.

```python
docs = Docs()
zotero = ZoteroDB(library_type="user")

for item in zotero.iterate(limit=20):
    if item.num_pages > 30:
        continue  # skip long papers
    docs.add(item.pdf, key=item.key)
```

This uses the existing `pypdf` import, and takes about 2ms for a 20 page paper. 

Could also be useful to expose this to the paper scraper interface?

---

This also refactors a few things:

1. Moves custom types (`StrPath`) into `types.py`.
2. Cleans up `ZoteroPaper` implementation.