### PR TITLE
Fix missing `_doc_index`

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -246,6 +246,7 @@ class Docs:
         except:
             # they use some special exception type, but I don't want to import it
             self._faiss_index = None
+        self._doc_index = None
         self.update_llm(None, None)
 
     def _build_faiss_index(self):

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -246,7 +246,8 @@ class Docs:
         except:
             # they use some special exception type, but I don't want to import it
             self._faiss_index = None
-        self._doc_index = None
+        if not hasattr(self, "_doc_index"):
+            self._doc_index = None
         self.update_llm(None, None)
 
     def _build_faiss_index(self):


### PR DESCRIPTION
Currently when you try to load a pickled version of `Docs()`, and then run `query()`, it complains about `_doc_index` not existing. This fixes this error by setting it in the `__setstate__` attribute: