### PR TITLE
Allow user to specify LangChain OpenAIEmbeddings kwargs in Docs init

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -42,6 +42,7 @@ class Docs:
         name: str = "default",
         index_path: Optional[Path] = None,
         embeddings: Optional[Embeddings] = None,
+        embeddings_kwargs: dict = {},
     ) -> None:
         """Initialize the collection of documents.
 
@@ -63,7 +64,7 @@ class Docs:
         self.index_path = index_path
         self.name = name
         if embeddings is None:
-            embeddings = OpenAIEmbeddings()
+            embeddings = OpenAIEmbeddings(**embeddings_kwargs)
         self.embeddings = embeddings
 
     def update_llm(


### PR DESCRIPTION
## What does this do?
Add an extra argument `embeddings_kwargs` to the `Docs` init method so that users can specify init method arguments for `Docs.embedding` when `OpenAIEmbeddings` is used.

## Why would you want to do this?

I encountered an issue where a special token ends up in the text that goes into OpenAIEmbeddings.embed_documents. See the stack trace below. The openai library suggests to pass in a `disallowed_special_tokens` argument - this is easy to do from the Docs init method if we add a new argument embeddings_kwargs. 

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 answer = docs.query("What pipeline is proposed in the Baize paper?")

File [~/paper-qa/paperqa/docs.py:375](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/paper-qa/paperqa/docs.py:375), in Docs.query(self, query, k, max_sources, length_prompt, marginal_relevance, answer, key_filter)
    373     loop = asyncio.new_event_loop()
    374     asyncio.set_event_loop(loop)
--> 375 return loop.run_until_complete(
    376     self.aquery(
    377         query,
    378         k=k,
    379         max_sources=max_sources,
    380         length_prompt=length_prompt,
    381         marginal_relevance=marginal_relevance,
    382         answer=answer,
    383         key_filter=key_filter,
    384     )
    385 )

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/nest_asyncio.py:90](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/nest_asyncio.py:90), in _patch_loop..run_until_complete(self, future)
     87 if not f.done():
     88     raise RuntimeError(
     89         'Event loop stopped before Future completed.')
---> 90 return f.result()

File [~/opt/miniconda3/envs/qa/lib/python3.11/asyncio/futures.py:203](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/asyncio/futures.py:203), in Future.result(self)
    201 self.__log_traceback = False
    202 if self._exception is not None:
--> 203     raise self._exception.with_traceback(self._exception_tb)
    204 return self._result

File [~/opt/miniconda3/envs/qa/lib/python3.11/asyncio/tasks.py:267](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/asyncio/tasks.py:267), in Task.__step(***failed resolving arguments***)
    263 try:
    264     if exc is None:
    265         # We use the `send` method directly, because coroutines
    266         # don't have `__iter__` and `__next__` methods.
--> 267         result = coro.send(None)
    268     else:
    269         result = coro.throw(exc)

File [~/paper-qa/paperqa/docs.py:407](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/paper-qa/paperqa/docs.py:407), in Docs.aquery(self, query, k, max_sources, length_prompt, marginal_relevance, answer, key_filter)
    405         answer.tokens += cb.total_tokens
    406         answer.cost += cb.total_cost
--> 407     answer = await self.aget_evidence(
    408         answer,
    409         k=k,
    410         max_sources=max_sources,
    411         marginal_relevance=marginal_relevance,
    412         key_filter=keys if key_filter else None,
    413     )
    414 context_str, contexts = answer.context, answer.contexts
    415 bib = dict()

File [~/paper-qa/paperqa/docs.py:277](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/paper-qa/paperqa/docs.py:277), in Docs.aget_evidence(self, answer, k, max_sources, marginal_relevance, key_filter)
    275     return answer
    276 if self._faiss_index is None:
--> 277     self._build_faiss_index()
    278 _k = k
    279 if key_filter is not None:

File [~/paper-qa/paperqa/docs.py:234](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/paper-qa/paperqa/docs.py:234), in Docs._build_faiss_index(self)
    228 texts = reduce(
    229     lambda x, y: x + y, [doc["texts"] for doc in self.docs.values()], []
    230 )
    231 metadatas = reduce(
    232     lambda x, y: x + y, [doc["metadata"] for doc in self.docs.values()], []
    233 )
--> 234 self._faiss_index = FAISS.from_texts(
    235     texts, self.embeddings, metadatas=metadatas
    236 )

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/vectorstores/faiss.py:344](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/vectorstores/faiss.py:344), in FAISS.from_texts(cls, texts, embedding, metadatas, **kwargs)
    319 @classmethod
    320 def from_texts(
    321     cls,
   (...)
    325     **kwargs: Any,
    326 ) -> FAISS:
    327     """Construct FAISS wrapper from raw documents.
    328 
    329     This is a user friendly interface that:
   (...)
    342             faiss = FAISS.from_texts(texts, embeddings)
    343     """
--> 344     embeddings = embedding.embed_documents(texts)
    345     return cls.__from(texts, embeddings, embedding, metadatas, **kwargs)

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/embeddings/openai.py:275](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/embeddings/openai.py:275), in OpenAIEmbeddings.embed_documents(self, texts, chunk_size)
    273 # handle batches of large input text
    274 if self.embedding_ctx_length > 0:
--> 275     return self._get_len_safe_embeddings(texts, engine=self.document_model_name)
    276 else:
    277     results = []

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/embeddings/openai.py:210](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/langchain/embeddings/openai.py:210), in OpenAIEmbeddings._get_len_safe_embeddings(self, texts, engine, chunk_size)
    207 for i, text in enumerate(texts):
    208     # replace newlines, which can negatively affect performance.
    209     text = text.replace("\n", " ")
--> 210     token = encoding.encode(
    211         text,
    212         allowed_special=self.allowed_special,
    213         disallowed_special=self.disallowed_special,
    214     )
    215     for j in range(0, len(token), self.embedding_ctx_length):
    216         tokens += [token[j : j + self.embedding_ctx_length]]

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/tiktoken/core.py:117](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/tiktoken/core.py:117), in Encoding.encode(self, text, allowed_special, disallowed_special)
    115         disallowed_special = frozenset(disallowed_special)
    116     if match := _special_token_regex(disallowed_special).search(text):
--> 117         raise_disallowed_special_token(match.group())
    119 try:
    120     return self._core_bpe.encode(text, allowed_special)

File [~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/tiktoken/core.py:337](https://file+.vscode-resource.vscode-cdn.net/Users/gabe/paper-qa/~/opt/miniconda3/envs/qa/lib/python3.11/site-packages/tiktoken/core.py:337), in raise_disallowed_special_token(token)
    336 def raise_disallowed_special_token(token: str) -> NoReturn:
--> 337     raise ValueError(
    338         f"Encountered text corresponding to disallowed special token {token!r}.\n"
    339         "If you want this text to be encoded as a special token, "
    340         f"pass it to `allowed_special`, e.g. `allowed_special={{{token!r}, ...}}`.\n"
    341         f"If you want this text to be encoded as normal text, disable the check for this token "
    342         f"by passing `disallowed_special=(enc.special_tokens_set - {{{token!r}}})`.\n"
    343         "To disable this check for all special tokens, pass `disallowed_special=()`.\n"
    344     )

ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'.
If you want this text to be encoded as a special token, pass it to `allowed_special`, e.g. `allowed_special={'<|endoftext|>', ...}`.
If you want this text to be encoded as normal text, disable the check for this token by passing `disallowed_special=(enc.special_tokens_set - {'<|endoftext|>'})`.
To disable this check for all special tokens, pass `disallowed_special=()`.
```