### PR TITLE
ci: fix langchain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "pypdf",
         "pydantic<2",
-        "langchain>=0.0.198",
+        "langchain<0.0.324>=0.0.198",
         "openai >= 0.27.8",
         "faiss-cpu",
         "PyCryptodome",


### PR DESCRIPTION
fix langchain dependency to below v0.0.324 due to incompatibilities of the current code base with newer `langchain` versions (fixes https://github.com/whitead/paper-qa/issues/199)

```
langchain<0.0.324>=0.0.198
```