### PR TITLE
Added `py.typed` metadata file

### DIFF
--- a/paperqa/version.py
+++ b/paperqa/version.py
@@ -1,1 +1,1 @@
-__version__ = "4.0.0-pre.8"
+__version__ = "4.0.0-pre.9"

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url="https://github.com/whitead/paper-qa",
     license="Apache License 2.0",
     packages=["paperqa", "paperqa.contrib"],
+    package_data={"paperqa": ["py.typed"]},
     install_requires=[
         "pypdf",
         "pydantic>=2",


### PR DESCRIPTION
Adds a missing `py.typed` file to satisfy `mypy` for client repos.

With this Python file:

```python
# a.py

from paperqa import Doc
```

Running `pip install paper-qa==3.13.4 mypy==1.8.0` then `mypy a.py`:

```none
a.py:3: error: Skipping analyzing "paperqa": module is installed, but missing library stubs or py.typed marker  [import-untyped]
a.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

Now running `pip install git+https://github.com/whitead/paper-qa@py-typed mypy==1.8.0` then `mypy a.py`:

```none
Success: no issues found in 1 source file
```