### PR TITLE
Allowing `Doc` subclasses to propagate to evidence

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -734,11 +734,12 @@ class Docs(BaseModel):
                     context = strip_citations(context)
             c = Context(
                 context=context,
-                # below will remove embedding from Text/Doc
                 text=Text(
                     text=match.text,
                     name=match.name,
-                    doc=Doc(**match.doc.model_dump()),
+                    doc=match.doc.__class__(
+                        **match.doc.model_dump(exclude="embedding")
+                    ),
                 ),
                 score=score,
                 **extras,

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -501,11 +501,19 @@ def test_evidence():
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
+    original_doc = next(iter(docs.docs.values()))
+    assert (
+        original_doc.embedding is not None
+    ), "For downstream assertions of in-tact embedding, we need an embedding"
     evidence = docs.get_evidence(
         Answer(question="For which state was Bates a governor?"), k=1, max_sources=1
     )
     print(evidence.context)
     assert "Missouri" in evidence.context
+    assert original_doc.embedding is not None, "Embedding should have remained in-tact"
+    assert (
+        evidence.contexts[0].text.doc.embedding is None
+    ), "Embedding should have been removed"
 
     evidence = docs.get_evidence(
         Answer(question="For which state was Bates a governor?"),


### PR DESCRIPTION
- By specifically listing `Doc` during evidence gathering, we removed the chances for subclasses to exist
- We had a comment about removing the `embedding`, but we didn't actually remove it. This PR actually removes it