### PR TITLE
Fixing crash when `json.loads` returns `str`

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -708,17 +708,15 @@ class Docs(BaseModel):
                     except json.decoder.JSONDecodeError:
                         # fallback to string
                         success = False
+                    else:
+                        success = isinstance(result_data, dict)
                     if success:
                         try:
-                            context = result_data["summary"]
-                            score = result_data["relevance_score"]
-                            del result_data["summary"]
-                            del result_data["relevance_score"]
-                            if "question" in result_data:
-                                del result_data["question"]
+                            context = result_data.pop("summary")
+                            score = result_data.pop("relevance_score")
+                            result_data.pop("question", None)
                             extras = result_data
                         except KeyError:
-                            # fallback
                             success = False
                 # fallback to string (or json mode not enabled)
                 if not success or not self.prompts.summary_json:


### PR DESCRIPTION
Check this:

```python
import json

assert isinstance(json.loads('"M. Thompson et al. (2021) studied mRNA-based COVID-19 vaccines in adults 50 years and older, finding high effectiveness against SARS-CoV-2 infection leading to severe outcomes. They indicated the need for completing vaccination for mRNA vaccines and noted potential effectiveness of the Ad26.COV2.S vaccine. Despite increased concern about SARS-CoV-2 variants during the study, most observations relate to the dominant B.1.1.7 (alpha) variant regionally. However, potential biases exist in vaccine effectiveness estimates due to possible misclassifications. The report\'s findings emphasize the importance of widespread vaccination to tackle COVID-19. Morbi blandit, nunc id pharetra volutpat. 8."'), dict)
```

The issue is that `json.loads` can return a string, which causes a crash when the downstream code assumes the return of `json.loads` is a `dict`. This PR fixes the issue