### PR TITLE
Upgrade of `ruff`, adding `codespell`, `toml-sort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,15 +2,23 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
       - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: check-added-large-files
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.0.270"
+    rev: v0.3.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -24,14 +32,18 @@ repos:
       - id: mypy
         args: [--pretty, --ignore-missing-imports]
         additional_dependencies: [types-requests, types-setuptools]
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.12.0"
-    hooks:
-      - id: isort
-        args: [--profile=black, "--skip=__init__.py", "--filter-files"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
         additional_dependencies:
           - prettier@3.2.5 # SEE: https://github.com/pre-commit/pre-commit/issues/3133
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.23.1
+    hooks:
+      - id: toml-sort-fix
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies: [".[toml]"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,2 +1,0 @@
-# Allow lines to be as longer.
-line-length = 180

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ It's not that different! This is similar to the tree response method in LlamaInd
 
 ### How is this different from LangChain?
 
-There has been some great work on retrievers in langchain and you could say this is an example of a retreiver.
+There has been some great work on retrievers in langchain and you could say this is an example of a retriever.
 
 ### Can I save or load?
 

--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -1,21 +1,21 @@
-from .docs import Answer, Docs, PromptCollection, Doc, Text, Context, print_callback
-from .version import __version__
+from .docs import Answer, Context, Doc, Docs, PromptCollection, Text, print_callback
 from .llms import (
-    LLMModel,
-    EmbeddingModel,
-    LangchainEmbeddingModel,
-    OpenAIEmbeddingModel,
-    LangchainLLMModel,
-    OpenAILLMModel,
     AnthropicLLMModel,
-    LlamaEmbeddingModel,
+    EmbeddingModel,
     HybridEmbeddingModel,
-    SparseEmbeddingModel,
-    NumpyVectorStore,
+    LangchainEmbeddingModel,
+    LangchainLLMModel,
     LangchainVectorStore,
-    SentenceTransformerEmbeddingModel,
+    LlamaEmbeddingModel,
+    LLMModel,
     LLMResult,
+    NumpyVectorStore,
+    OpenAIEmbeddingModel,
+    OpenAILLMModel,
+    SentenceTransformerEmbeddingModel,
+    SparseEmbeddingModel,
 )
+from .version import __version__
 
 __all__ = [
     "Docs",

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -17,7 +17,7 @@ from ..utils import StrPath, count_pdf_pages
 class ZoteroPaper(BaseModel):
     """A paper from Zotero.
 
-    Attributes
+    Attributes:
     ----------
     key : str
         The citation key.
@@ -247,7 +247,7 @@ class ZoteroDB(zotero.Zotero):
                 if no_pdf or is_duplicate:
                     continue
                 pdf = cast(Path, pdf)
-                title = item["data"]["title"] if "title" in item["data"] else ""
+                title = item["data"].get("title", "")
                 if len(items) >= start:
                     yield ZoteroPaper(
                         key=_get_citation_key(item),
@@ -277,7 +277,7 @@ class ZoteroDB(zotero.Zotero):
         """Get the collection id for a given collection name
             Raises ValueError if collection not found
         Args:
-            collection_name (str): The name of the collection
+            collection_name (str): The name of the collection.
 
         Returns:
             str: collection id
@@ -328,7 +328,6 @@ def _get_citation_key(item: dict) -> str:
 
 def _extract_pdf_key(item: dict) -> Union[str, None]:
     """Extract the PDF key from a Zotero item."""
-
     if "links" not in item:
         return None
 

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -282,7 +282,7 @@ class ZoteroDB(zotero.Zotero):
         Returns:
             str: collection id
         """
-        # specfic collection
+        # specific collection
         collections = self.collections()
         collection_id = ""
 

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 try:
     from pyzotero import zotero
 except ImportError:
-    raise ImportError("Please install pyzotero: `pip install pyzotero`")
+    raise ImportError("Please install pyzotero: `pip install pyzotero`")  # noqa: B904
 from ..paths import PAPERQA_DIR
 from ..utils import StrPath, count_pdf_pages
 
@@ -65,9 +65,9 @@ class ZoteroDB(zotero.Zotero):
         self,
         *,
         library_type: str = "user",
-        library_id: Optional[str] = None,
-        api_key: Optional[str] = None,
-        storage: Optional[StrPath] = None,
+        library_id: Optional[str] = None,  # noqa: FA100
+        api_key: Optional[str] = None,  # noqa: FA100
+        storage: Optional[StrPath] = None,  # noqa: FA100
         **kwargs,
     ):
         self.logger = logging.getLogger("ZoteroDB")
@@ -81,7 +81,7 @@ class ZoteroDB(zotero.Zotero):
                     " from the text 'Your userID for use in API calls is [XXXXXX]'."
                     " Then, set the environment variable ZOTERO_USER_ID to this value."
                 )
-            else:
+            else:  # noqa: RET506
                 library_id = os.environ["ZOTERO_USER_ID"]
 
         if api_key is None:
@@ -93,7 +93,7 @@ class ZoteroDB(zotero.Zotero):
                     " with access to your library."
                     " Then, set the environment variable ZOTERO_API_KEY to this value."
                 )
-            else:
+            else:  # noqa: RET506
                 api_key = os.environ["ZOTERO_API_KEY"]
 
         self.logger.info(f"Using library ID: {library_id} with type: {library_type}.")
@@ -108,7 +108,7 @@ class ZoteroDB(zotero.Zotero):
             library_type=library_type, library_id=library_id, api_key=api_key, **kwargs
         )
 
-    def get_pdf(self, item: dict) -> Union[Path, None]:
+    def get_pdf(self, item: dict) -> Union[Path, None]:  # noqa: FA100
         """Gets a filename for a given Zotero key for a PDF.
 
         If the PDF is not found locally, the PDF will be downloaded to a local file at the correct key.
@@ -120,7 +120,7 @@ class ZoteroDB(zotero.Zotero):
             An item from `pyzotero`. Should have a `key` field, and also have an entry
             `links->attachment->attachmentType == application/pdf`.
         """
-        if type(item) != dict:
+        if type(item) != dict:  # noqa: E721
             raise TypeError("Pass the full item of the paper. The item must be a dict.")
 
         pdf_key = _extract_pdf_key(item)
@@ -137,17 +137,17 @@ class ZoteroDB(zotero.Zotero):
 
         return pdf_path
 
-    def iterate(
+    def iterate(  # noqa: C901, PLR0912
         self,
         limit: int = 25,
         start: int = 0,
-        q: Optional[str] = None,
-        qmode: Optional[str] = None,
-        since: Optional[str] = None,
-        tag: Optional[str] = None,
-        sort: Optional[str] = None,
-        direction: Optional[str] = None,
-        collection_name: Optional[str] = None,
+        q: Optional[str] = None,  # noqa: FA100
+        qmode: Optional[str] = None,  # noqa: FA100
+        since: Optional[str] = None,  # noqa: FA100
+        tag: Optional[str] = None,  # noqa: FA100
+        sort: Optional[str] = None,  # noqa: FA100
+        direction: Optional[str] = None,  # noqa: FA100
+        collection_name: Optional[str] = None,  # noqa: FA100
     ):
         """Given a search query, this will lazily iterate over papers in a Zotero library, downloading PDFs as needed.
 
@@ -210,8 +210,8 @@ class ZoteroDB(zotero.Zotero):
 
         max_limit = 100
 
-        items: List = []
-        pdfs: List[Path] = []
+        items: List = []  # noqa: FA100
+        pdfs: List[Path] = []  # noqa: FA100
         i = 0
         actual_i = 0
         num_remaining = limit
@@ -281,7 +281,7 @@ class ZoteroDB(zotero.Zotero):
 
         Returns:
             str: collection id
-        """
+        """  # noqa: D205
         # specific collection
         collections = self.collections()
         collection_id = ""
@@ -326,7 +326,7 @@ def _get_citation_key(item: dict) -> str:
     return f"{last_name}_{short_title}_{date}_{item['key']}".replace(" ", "")
 
 
-def _extract_pdf_key(item: dict) -> Union[str, None]:
+def _extract_pdf_key(item: dict) -> Union[str, None]:  # noqa: FA100
     """Extract the PDF key from a Zotero item."""
     if "links" not in item:
         return None
@@ -336,7 +336,7 @@ def _extract_pdf_key(item: dict) -> Union[str, None]:
 
     attachments = item["links"]["attachment"]
 
-    if type(attachments) != dict:
+    if type(attachments) != dict:  # noqa: E721
         # Find first attachment with attachmentType == application/pdf:
         for attachment in attachments:
             # TODO: This assumes there's only one PDF attachment.

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-import pprint
+import pprint  # noqa: F401
 import re
 import tempfile
 from datetime import datetime
@@ -52,11 +52,11 @@ from .utils import (
 
 
 # this is just to reduce None checks/type checks
-async def empty_callback(result: LLMResult):
+async def empty_callback(result: LLMResult):  # noqa: ARG001
     pass
 
 
-async def print_callback(result: LLMResult):
+async def print_callback(result: LLMResult):  # noqa: ARG001
     pass
 
 
@@ -140,7 +140,7 @@ class Docs(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def setup_alias_models(cls, data: Any) -> Any:
+    def setup_alias_models(cls, data: Any) -> Any:  # noqa: C901, PLR0912
         if isinstance(data, dict):
             if "llm" in data and data["llm"] != "default":
                 if is_openai_model(data["llm"]):
@@ -351,7 +351,7 @@ class Docs(BaseModel):
         """Add a document to the collection."""
         import urllib.request
 
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(url) as f:  # noqa: ASYNC100, S310
             # need to wrap to enable seek
             file = BytesIO(f.read())
             return await self.aadd_file(
@@ -409,7 +409,11 @@ class Docs(BaseModel):
                 raise ValueError(f"Could not read document {path}. Is it empty?")
             chain_result = await cite_chain({"text": texts[0].text}, None)
             citation = chain_result.text
-            if len(citation) < 3 or "Unknown" in citation or "insufficient" in citation:
+            if (
+                len(citation) < 3  # noqa: PLR2004
+                or "Unknown" in citation
+                or "insufficient" in citation
+            ):
                 citation = f"Unknown, {os.path.basename(path)}, {datetime.now().year}"
 
         if docname is None:
@@ -435,7 +439,7 @@ class Docs(BaseModel):
         # loose check to see if document was loaded
         if (
             len(texts) == 0
-            or len(texts[0].text) < 10
+            or len(texts[0].text) < 10  # noqa: PLR2004
             or (not disable_check and not maybe_is_text(texts[0].text))
         ):
             raise ValueError(
@@ -516,7 +520,7 @@ class Docs(BaseModel):
         query: str,
         k: int = 25,
         rerank: bool | None = None,
-        get_callbacks: CallbackFactory = lambda x: None,
+        get_callbacks: CallbackFactory = lambda x: None,  # noqa: ARG005
         answer: Answer | None = None,  # used for tracking tokens
     ) -> set[DocKey]:
         """Return a list of dockeys that match the query."""
@@ -588,7 +592,7 @@ class Docs(BaseModel):
         answer: Answer,
         k: int = 10,
         max_sources: int = 5,
-        get_callbacks: CallbackFactory = lambda x: None,
+        get_callbacks: CallbackFactory = lambda x: None,  # noqa: ARG005
         detailed_citations: bool = False,
         disable_vector_search: bool = False,
     ) -> Answer:
@@ -603,12 +607,12 @@ class Docs(BaseModel):
             )
         )
 
-    async def aget_evidence(
+    async def aget_evidence(  # noqa: C901, PLR0915
         self,
         answer: Answer,
         k: int = 10,  # Number of evidence pieces to retrieve
         max_sources: int = 5,  # Number of scored contexts to use
-        get_callbacks: CallbackFactory = lambda x: None,
+        get_callbacks: CallbackFactory = lambda x: None,  # noqa: ARG005
         detailed_citations: bool = False,
         disable_vector_search: bool = False,
     ) -> Answer:
@@ -644,7 +648,7 @@ class Docs(BaseModel):
         # now finally cut down
         matches = matches[:k]
 
-        async def process(match):
+        async def process(match):  # noqa: C901, PLR0912
             callbacks = get_callbacks("evidence:" + match.name)
             citation = match.doc.citation
             # needed empties for failures/skips
@@ -773,7 +777,7 @@ class Docs(BaseModel):
         length_prompt="about 100 words",
         answer: Answer | None = None,
         key_filter: bool | None = None,
-        get_callbacks: CallbackFactory = lambda x: None,
+        get_callbacks: CallbackFactory = lambda x: None,  # noqa: ARG005
     ) -> Answer:
         return get_loop().run_until_complete(
             self.aquery(
@@ -787,7 +791,7 @@ class Docs(BaseModel):
             )
         )
 
-    async def aquery(
+    async def aquery(  # noqa: C901, PLR0912, PLR0915
         self,
         query: str,
         k: int = 10,
@@ -795,7 +799,7 @@ class Docs(BaseModel):
         length_prompt: str = "about 100 words",
         answer: Answer | None = None,
         key_filter: bool | None = None,
-        get_callbacks: CallbackFactory = lambda x: None,
+        get_callbacks: CallbackFactory = lambda x: None,  # noqa: ARG005
     ) -> Answer:
         if k < max_sources:
             raise ValueError("k should be greater than max_sources")
@@ -833,7 +837,7 @@ class Docs(BaseModel):
                 answer.context + "\n\nExtra background information:" + str(pre)
             )
         bib = {}
-        if len(answer.context) < 10:  # and not self.memory:
+        if len(answer.context) < 10:  # and not self.memory:  # noqa: PLR2004
             answer_text = (
                 "I cannot answer this question due to insufficient information."
             )

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -76,7 +76,7 @@ def process_llm_config(llm_config: dict, max_token_name: str = "max_tokens") -> 
     if max_token_name not in result or result[max_token_name] == -1:
         model = llm_config["model"]
         # now we guess - we could use tiktoken to count,
-        # but do have the initative right now
+        # but do have the initiative right now
         if model.startswith("gpt-4") or (
             model.startswith("gpt-3.5") and "1106" in model
         ):

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -11,7 +11,7 @@ summary_prompt = (
 )
 
 summary_json_prompt = (
-    "Excerpt from {citation}\n\n----\n\n{text}\n\n----\n\n" "Question: {question}\n\n"
+    "Excerpt from {citation}\n\n----\n\n{text}\n\n----\n\nQuestion: {question}\n\n"
 )
 
 qa_prompt = (

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from math import ceil
 from pathlib import Path
 from typing import List
@@ -8,13 +10,13 @@ from html2text import html2text
 from .types import Doc, Text
 
 
-def parse_pdf_fitz(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> List[Text]:
+def parse_pdf_fitz(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> list[Text]:
     import fitz
 
     file = fitz.open(path)
     split = ""
-    pages: List[str] = []
-    texts: List[Text] = []
+    pages: list[str] = []
+    texts: list[Text] = []
     for i in range(file.page_count):
         page = file.load_page(i)
         split += page.get_text("text", sort=True)
@@ -41,14 +43,14 @@ def parse_pdf_fitz(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> List
     return texts
 
 
-def parse_pdf(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> List[Text]:
+def parse_pdf(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> list[Text]:
     import pypdf
 
     pdfFileObj = open(path, "rb")
     pdfReader = pypdf.PdfReader(pdfFileObj)
     split = ""
-    pages: List[str] = []
-    texts: List[Text] = []
+    pages: list[str] = []
+    texts: list[Text] = []
     for i, page in enumerate(pdfReader.pages):
         split += page.extract_text()
         pages.append(str(i + 1))
@@ -76,7 +78,7 @@ def parse_pdf(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> List[Text
 
 def parse_txt(
     path: Path, doc: Doc, chunk_chars: int, overlap: int, html: bool = False
-) -> List[Text]:
+) -> list[Text]:
     """Parse a document into chunks, based on tiktoken encoding.
 
     NOTE: We get some byte continuation errors.
@@ -120,11 +122,10 @@ def parse_txt(
     return texts
 
 
-def parse_code_txt(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> List[Text]:
+def parse_code_txt(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> list[Text]:
     """Parse a document into chunks, based on line numbers (for code)."""
-
     split = ""
-    texts: List[Text] = []
+    texts: list[Text] = []
     last_line = 0
 
     with open(path) as f:
@@ -157,7 +158,7 @@ def read_doc(
     chunk_chars: int = 3000,
     overlap: int = 100,
     force_pypdf: bool = False,
-) -> List[Text]:
+) -> list[Text]:
     """Parse a document into chunks."""
     str_path = str(path)
     if str_path.endswith(".pdf"):

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -80,7 +80,7 @@ def parse_txt(
     """Parse a document into chunks, based on tiktoken encoding.
 
     NOTE: We get some byte continuation errors.
-    Currnetly ignored, but should explore more to make sure we
+    Currently ignored, but should explore more to make sure we
     don't miss anything.
     """
     try:

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from math import ceil
 from pathlib import Path
-from typing import List
+from typing import List  # noqa: F401
 
 import tiktoken
 from html2text import html2text
@@ -46,7 +46,7 @@ def parse_pdf_fitz(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> list
 def parse_pdf(path: Path, doc: Doc, chunk_chars: int, overlap: int) -> list[Text]:
     import pypdf
 
-    pdfFileObj = open(path, "rb")
+    pdfFileObj = open(path, "rb")  # noqa: SIM115
     pdfReader = pypdf.PdfReader(pdfFileObj)
     split = ""
     pages: list[str] = []

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable
 from uuid import UUID, uuid4
 
@@ -75,7 +77,7 @@ class _FormatDict(dict):
 
 
 def get_formatted_variables(s: str) -> set[str]:
-    """Returns the set of variables implied by the format string"""
+    """Returns the set of variables implied by the format string."""
     format_dict = _FormatDict()
     s.format_map(format_dict)
     return format_dict.key_set
@@ -133,9 +135,8 @@ class PromptCollection(BaseModel):
     @field_validator("pre")
     @classmethod
     def check_pre(cls, v: str | None) -> str | None:
-        if v is not None:
-            if set(get_formatted_variables(v)) != set(["question"]):
-                raise ValueError("Pre prompt must have input variables: question")
+        if v is not None and set(get_formatted_variables(v)) != {"question"}:
+            raise ValueError("Pre prompt must have input variables: question")
         return v
 
     @field_validator("post")

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -161,7 +161,7 @@ class Context(BaseModel):
     )
 
 
-def __str__(self) -> str:
+def __str__(self) -> str:  # noqa: N807
     """Return the context as a string."""
     return self.context
 
@@ -208,7 +208,7 @@ class Answer(BaseModel):
         try:
             doc = next(filter(lambda x: x.text.name == name, self.contexts)).text.doc
         except StopIteration:
-            raise ValueError(f"Could not find docname {name} in contexts")
+            raise ValueError(f"Could not find docname {name} in contexts")  # noqa: B904
         return doc.citation
 
     def add_tokens(self, result: LLMResult):

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -203,7 +203,7 @@ class Answer(BaseModel):
         return get_citenames(self.formatted_answer)
 
     def get_citation(self, name: str) -> str:
-        """Return the formatted citation for the gien docname."""
+        """Return the formatted citation for the given docname."""
         try:
             doc = next(filter(lambda x: x.text.name == name, self.contexts)).text.doc
         except StopIteration:

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import math
@@ -13,7 +15,7 @@ StrPath = Union[str, Path]
 
 def name_in_text(name: str, text: str) -> bool:
     sname = name.strip()
-    pattern = r"\b({0})\b(?!\w)".format(re.escape(sname))
+    pattern = rf"\b({re.escape(sname)})\b(?!\w)"
     if re.search(pattern, text):
         return True
     return False
@@ -44,12 +46,7 @@ def maybe_is_pdf(file: BinaryIO) -> bool:
 def maybe_is_html(file: BinaryIO) -> bool:
     magic_number = file.read(4)
     file.seek(0)
-    return (
-        magic_number == b"<htm"
-        or magic_number == b"<!DO"
-        or magic_number == b"<xsl"
-        or magic_number == b"<!X"
-    )
+    return magic_number in (b"<htm", b"<!DO", b"<xsl", b"<!X")
 
 
 def strings_similarity(s1: str, s2: str) -> float:
@@ -103,8 +100,7 @@ def strip_citations(text: str) -> str:
     # Combined regex for identifying citations (see unit tests for examples)
     citation_regex = r"\b[\w\-]+\set\sal\.\s\([0-9]{4}\)|\((?:[^\)]*?[a-zA-Z][^\)]*?[0-9]{4}[^\)]*?)\)"
     # Remove the citations from the text
-    text = re.sub(citation_regex, "", text, flags=re.MULTILINE)
-    return text
+    return re.sub(citation_regex, "", text, flags=re.MULTILINE)
 
 
 def get_citenames(text: str) -> set[str]:
@@ -147,7 +143,7 @@ def extract_doi(reference: str) -> str:
 
 def batch_iter(iterable: list, n: int = 1) -> Iterator[list]:
     """
-    Batch an iterable into chunks of size n
+    Batch an iterable into chunks of size n.
 
     :param iterable: The iterable to batch
     :param n: The size of the batches
@@ -160,7 +156,7 @@ def batch_iter(iterable: list, n: int = 1) -> Iterator[list]:
 
 def flatten(iteratble: list) -> list:
     """
-    Flatten a list of lists
+    Flatten a list of lists.
 
     :param l: The list of lists to flatten
     :return: A flattened list

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -76,7 +76,7 @@ def md5sum(file_path: StrPath) -> str:
     import hashlib
 
     with open(file_path, "rb") as f:
-        return hashlib.md5(f.read()).hexdigest()
+        return hashlib.md5(f.read()).hexdigest()  # noqa: S324
 
 
 async def gather_with_concurrency(n: int, coros: list[Coroutine]) -> list[Any]:
@@ -113,12 +113,12 @@ def get_citenames(text: str) -> set[str]:
     results.extend(none_results)
     values = []
     for citation in results:
-        citation = citation.strip("() ")
+        citation = citation.strip("() ")  # noqa: PLW2901
         for c in re.split(",|;", citation):
             if c == "Extra background information":
                 continue
             # remove leading/trailing spaces
-            c = c.strip()
+            c = c.strip()  # noqa: PLW2901
             values.append(c)
     return set(values)
 
@@ -137,7 +137,7 @@ def extract_doi(reference: str) -> str:
     # If DOI is found in the reference, return the DOI link
     if doi_match:
         return "https://doi.org/" + doi_match.group()
-    else:
+    else:  # noqa: RET505
         return ""
 
 
@@ -176,6 +176,6 @@ def get_loop() -> asyncio.AbstractEventLoop:
 def is_coroutine_callable(obj):
     if inspect.isfunction(obj):
         return inspect.iscoroutinefunction(obj)
-    elif callable(obj):
+    elif callable(obj):  # noqa: RET505
         return inspect.iscoroutinefunction(obj.__call__)
     return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+# SEE: https://github.com/codespell-project/codespell/issues/1212#issuecomment-1744768533
+ignore-regex = ".{1024}|.*codespell-ignore.*"
+ignore-words-list = "aadd,ser"
+
 [tool.mypy]
 # Type-checks the interior of functions without type annotations.
 check_untyped_defs = true
@@ -47,3 +54,89 @@ module = [
     "pyzotero",  # SEE: https://github.com/urschrei/pyzotero/issues/110
     "sentence_transformers",  # SEE: https://github.com/UKPLab/sentence-transformers/issues/1723
 ]
+
+[tool.ruff]
+# Line length to use when enforcing long-lines violations (like `E501`).
+line-length = 120
+# Enable application of unsafe fixes.
+unsafe-fixes = true
+
+[tool.ruff.lint]
+# List of rule codes that are unsupported by Ruff, but should be preserved when
+# (e.g.) validating # noqa directives. Useful for retaining # noqa directives
+# that cover plugins not yet implemented by Ruff.
+ignore = [
+    "ANN",  # Don't care to enforce typing
+    "BLE001",  # Don't care to enforce blind exception catching
+    "COM812",  # Trailing comma with black leads to wasting lines
+    "D100",  # D100, D101, D102, D103, D104, D105, D106, D107: don't always need docstrings
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D203",  # Keep docstring next to the class definition (covered by D211)
+    "D212",  # Summary should be on second line (opposite of D213)
+    "D402",  # It's nice to reuse the method name
+    "D406",  # Google style requires ":" at end
+    "D407",  # We aren't using numpy style
+    "D413",  # Blank line after last section. -> No blank line
+    "DTZ",  # Don't care to have timezone safety
+    "EM",  # Overly pedantic
+    "ERA001",  # Don't care to prevent commented code
+    "FBT001",  # FBT001, FBT002: overly pedantic
+    "FBT002",
+    "FIX",  # Don't care to prevent TODO, FIXME, etc.
+    "FLY002",  # Can be less readable
+    "G004",  # f-strings are convenient
+    "INP001",  # Can use namespace packages
+    "N803",  # Want to use 'N', or 'L',
+    "N806",  # Want to use 'N', or 'L',
+    "PLR0913",
+    "PTH",  # Overly pedantic
+    "S311",  # Ok to use python random
+    "SLF001",  # Overly pedantic
+    "T201",  # Overly pedantic
+    "TCH001",  # TCH001, TCH002, TCH003: don't care to enforce type checking blocks
+    "TCH002",
+    "TCH003",
+    "TD002",  # Don't care for TODO author
+    "TD003",  # Don't care for TODO links
+    "TID252",  # Allow relative imports for packaging
+    "TRY003",  # Overly pedantic
+]
+select = ["ALL"]
+unfixable = [
+    "B007",  # While debugging, unused loop variables can be useful
+    "ERA001",  # While debugging, temporarily commenting code can be useful
+    "F401",  # While debugging, unused imports can be useful
+    "F841",  # While debugging, unused locals can be useful
+]
+
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = [
+    "PLR2004",  # Tests can have magic values
+    "S101",  # Tests can have assertions
+]
+
+[tool.ruff.lint.pycodestyle]
+# The maximum line length to allow for line-length violations within
+# documentation (W505), including standalone comments.
+max-doc-length = 120  # Match line-length
+
+[tool.ruff.lint.pydocstyle]
+# Whether to use Google-style or NumPy-style conventions or the PEP257
+# defaults when analyzing docstring sections.
+convention = "google"
+
+[tool.tomlsort]
+all = true
+in_place = true
+spaces_before_inline_comment = 2  # Match Python PEP 8
+spaces_indent_inline_array = 4  # Match Python PEP 8
+trailing_comma_inline_array = true

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 __version__ = ""
 exec(open("paperqa/version.py").read())
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 # for typing
 __version__ = ""
-exec(open("paperqa/version.py").read())
+exec(open("paperqa/version.py").read())  # noqa: S102, SIM115
 
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -173,7 +173,7 @@ def test_ablations():
         docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
         answer = docs.get_evidence(
             Answer(
-                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"
+                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"  # noqa: ISC003
                 + "chemistry because it can accurately model non-linear structure-function relationships.' on?"
             )
         )
@@ -182,7 +182,7 @@ def test_ablations():
         ), "summarization not ablated"
         answer = docs.get_evidence(
             Answer(
-                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"
+                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"  # noqa: ISC003
                 + "chemistry because it can accurately model non-linear structure-function relationships.' on?"
             ),
             disable_vector_search=True,
@@ -197,7 +197,7 @@ def test_location_awareness():
         docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
         answer = docs.get_evidence(
             Answer(
-                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"
+                question="Which page is the statement 'Deep learning (DL) is advancing the boundaries of computational"  # noqa: ISC003
                 + "chemistry because it can accurately model non-linear structure-function relationships.' on?"
             ),
             detailed_citations=True,
@@ -209,7 +209,9 @@ def test_maybe_is_text():
     assert maybe_is_text("This is a test. The sample conc. was 1.0 mM (at 245 ^F)")
     assert not maybe_is_text("\\C0\\C0\\B1\x00")
     # get front page of wikipedia
-    r = requests.get("https://en.wikipedia.org/wiki/National_Flag_of_Canada_Day")
+    r = requests.get(  # noqa: S113
+        "https://en.wikipedia.org/wiki/National_Flag_of_Canada_Day"
+    )
     assert maybe_is_text(r.text)
 
     assert maybe_is_html(BytesIO(r.text.encode()))
@@ -456,7 +458,7 @@ class TestChains(IsolatedAsyncioTestCase):
         assert completion.seconds_to_last_token > 0
 
         # check with mixed callbacks
-        async def ac(x):
+        async def ac(x):  # noqa: ARG001
             pass
 
         completion = await call({"animal": "duck"}, callbacks=[accum, ac])  # type: ignore[call-arg]
@@ -506,7 +508,9 @@ def test_evidence():
     doc_path = "example.html"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -536,7 +540,9 @@ def test_json_evidence():
     doc_path = "example.html"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     summary_llm = OpenAILLMModel(
         config={
@@ -569,7 +575,9 @@ def test_custom_json_props():
     doc_path = "example.html"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     summary_llm = OpenAILLMModel(
         config={
@@ -580,7 +588,7 @@ def test_custom_json_props():
     )
     my_prompts = PromptCollection(
         json_summary=True,
-        summary_json_system="Provide a summary of the excerpt that could help answer the question based on the excerpt.  "
+        summary_json_system="Provide a summary of the excerpt that could help answer the question based on the excerpt.  "  # noqa: E501
         "The excerpt may be irrelevant. Do not directly answer the question - only summarize relevant information. "
         "Respond with the following JSON format:\n\n"
         '{{\n"summary": "...",\n"person_name": "...",\n"relevance_score": "..."}}\n\n'
@@ -689,7 +697,7 @@ def test_custom_embedding():
     class MyEmbeds(EmbeddingModel):
         name: str = "my_embed"
 
-        async def embed_documents(self, client, texts):
+        async def embed_documents(self, client, texts):  # noqa: ARG002
             return [[1, 2, 3] for _ in texts]
 
     docs = Docs(
@@ -776,7 +784,7 @@ def test_custom_llm():
     class MyLLM(LLMModel):
         name: str = "myllm"
 
-        async def acomplete(self, client, prompt):
+        async def acomplete(self, client, prompt):  # noqa: ARG002
             assert client is None
             return "Echo"
 
@@ -794,7 +802,7 @@ def test_custom_llm_stream():
     class MyLLM(LLMModel):
         name: str = "myllm"
 
-        async def acomplete_iter(self, client, prompt):
+        async def acomplete_iter(self, client, prompt):  # noqa: ARG002
             assert client is None
             yield "Echo"
 
@@ -805,7 +813,8 @@ def test_custom_llm_stream():
         dockey="test",
     )
     evidence = docs.get_evidence(
-        Answer(question="Echo"), get_callbacks=lambda x: [lambda y: print(y, end="")]
+        Answer(question="Echo"),
+        get_callbacks=lambda x: [lambda y: print(y, end="")],  # noqa: ARG005
     )
     assert "Echo" in evidence.context
 
@@ -829,7 +838,7 @@ def test_langchain_llm():
 
     docs.get_evidence(
         Answer(question="What is Frederick Bates's greatest accomplishment?"),
-        get_callbacks=lambda x: [lambda y: print(y, end="")],
+        get_callbacks=lambda x: [lambda y: print(y, end="")],  # noqa: ARG005
     )
 
     assert docs.llm_model.llm_type == "chat"
@@ -849,7 +858,7 @@ def test_langchain_llm():
     )
     docs.get_evidence(
         Answer(question="What is Frederick Bates's greatest accomplishment?"),
-        get_callbacks=lambda x: [lambda y: print(y, end="")],
+        get_callbacks=lambda x: [lambda y: print(y, end="")],  # noqa: ARG005
     )
 
     assert docs.summary_llm_model.llm_type == "completion"  # type: ignore[union-attr]
@@ -861,14 +870,14 @@ def test_langchain_llm():
 
     # now make sure we can pickle it
     docs_pickle = pickle.dumps(docs)
-    docs2 = pickle.loads(docs_pickle)
+    docs2 = pickle.loads(docs_pickle)  # noqa: S301
     assert docs2._client is None
     assert docs2.llm == "babbage-002"
     docs2.set_client(OpenAI(model="babbage-002"))
     assert docs2.summary_llm == "babbage-002"
     docs2.get_evidence(
         Answer(question="What is Frederick Bates's greatest accomplishment?"),
-        get_callbacks=lambda x: [lambda y: print(y)],
+        get_callbacks=lambda x: [lambda y: print(y)],  # noqa: ARG005
     )
 
 
@@ -913,19 +922,19 @@ class TestVectorStore(IsolatedAsyncioTestCase):
         try:
             index = LangchainVectorStore()
             index.add_texts_and_embeddings(some_texts)
-            raise "Failed to check for builder"  # type: ignore[misc]
+            raise "Failed to check for builder"  # type: ignore[misc]  # noqa: B016
         except ValueError:
             pass
 
         try:
-            index = LangchainVectorStore(store_builder=lambda x: None)
-            raise "Failed to count arguments"  # type: ignore[misc]
+            index = LangchainVectorStore(store_builder=lambda x: None)  # noqa: ARG005
+            raise "Failed to count arguments"  # type: ignore[misc]  # noqa: B016
         except ValueError:
             pass
 
         try:
             index = LangchainVectorStore(store_builder="foo")
-            raise "Failed to check if builder is callable"  # type: ignore[misc]
+            raise "Failed to check if builder is callable"  # type: ignore[misc]  # noqa: B016
         except ValueError:
             pass
 
@@ -983,7 +992,7 @@ class TestVectorStore(IsolatedAsyncioTestCase):
 
         # make sure we can pickle it
         docs_pickle = pickle.dumps(docs)
-        pickle.loads(docs_pickle)
+        pickle.loads(docs_pickle)  # noqa: S301
 
         # will not work at this point - have to reset index
 
@@ -1021,7 +1030,9 @@ def test_docs_pickle() -> None:
     # 1. Fill out docs
     with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8", suffix=".html") as f:
         # get front page of wikipedia
-        r = requests.get("https://en.wikipedia.org/wiki/Take_Your_Dog_to_Work_Day")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Take_Your_Dog_to_Work_Day"
+        )
         r.raise_for_status()
         f.write(r.text)
         docs = Docs(
@@ -1036,7 +1047,7 @@ def test_docs_pickle() -> None:
 
     # 2. Pickle and unpickle, checking unpickled is in-tact
     docs_pickle = pickle.dumps(docs)
-    docs2 = pickle.loads(docs_pickle)
+    docs2 = pickle.loads(docs_pickle)  # noqa: S301
     with pytest.raises(ValueError, match="forget to set it after pickling"):
         docs2.query("What date is bring your dog to work in the US?")
     docs2.set_client()
@@ -1080,7 +1091,9 @@ def test_bad_context():
     doc_path = "example.html"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -1093,13 +1106,15 @@ def test_repeat_keys():
     doc_path = "example.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs(
         llm_model=OpenAILLMModel(config={"temperature": 0.0, "model": "babbage-002"})
     )
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
-    try:
+    try:  # noqa: SIM105
         docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     except ValueError:
         pass
@@ -1145,7 +1160,9 @@ def test_fileio_reader_pdf():
 def test_fileio_reader_txt():
     # can't use curie, because it has trouble with parsed HTML
     docs = Docs()
-    r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+    r = requests.get(  # noqa: S113
+        "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+    )
     if r.status_code != 200:
         raise ValueError("Could not download wikipedia page")
     docs.add_file(
@@ -1184,7 +1201,9 @@ def test_prompt_length():
     doc_path = "example.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -1206,7 +1225,9 @@ def test_citation():
     doc_path = "example.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path)  # type: ignore[arg-type]
@@ -1223,7 +1244,9 @@ def test_dockey_filter():
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -1241,7 +1264,9 @@ def test_dockey_delete():
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -1275,7 +1300,9 @@ def test_query_filter():
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs = Docs()
     docs.add(
@@ -1306,7 +1333,7 @@ def test_too_much_evidence():
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Barack_Obama")
+        r = requests.get("https://en.wikipedia.org/wiki/Barack_Obama")  # noqa: S113
         f.write(r.text)
     docs = Docs(llm="gpt-3.5-turbo", summary_llm="gpt-3.5-turbo")
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
@@ -1335,7 +1362,9 @@ def test_custom_prompts():
     doc_path = "example.html"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     answer = docs.query("What country is Frederick Bates from?")
@@ -1350,7 +1379,9 @@ def test_pre_prompt():
     doc_path = "example.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     docs.query("What country is Bates from?")
@@ -1370,7 +1401,9 @@ def test_post_prompt():
     doc_path = "example.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
-        r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
+        r = requests.get(  # noqa: S113
+            "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)"
+        )
         f.write(r.text)
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     docs.query("What country is Bates from?")

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pickle
 import tempfile
@@ -407,7 +409,7 @@ def test_extract_score():
 class TestChains(IsolatedAsyncioTestCase):
     async def test_chain_completion(self):
         client = AsyncOpenAI()
-        llm = OpenAILLMModel(config=dict(model="babbage-002", temperature=0.2))
+        llm = OpenAILLMModel(config={"model": "babbage-002", "temperature": 0.2})
         call = llm.make_chain(
             client,
             "The {animal} says",
@@ -418,20 +420,20 @@ class TestChains(IsolatedAsyncioTestCase):
         def accum(x):
             outputs.append(x)
 
-        completion = await call(dict(animal="duck"), callbacks=[accum])  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"}, callbacks=[accum])  # type: ignore[call-arg]
         assert completion.seconds_to_first_token > 0
         assert completion.prompt_count > 0
         assert completion.completion_count > 0
         assert str(completion) == "".join(outputs)
 
-        completion = await call(dict(animal="duck"))  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"})  # type: ignore[call-arg]
         assert completion.seconds_to_first_token == 0
         assert completion.seconds_to_last_token > 0
 
     async def test_chain_chat(self):
         client = AsyncOpenAI()
         llm = OpenAILLMModel(
-            config=dict(temperature=0, model="gpt-3.5-turbo", max_tokens=56)
+            config={"temperature": 0, "model": "gpt-3.5-turbo", "max_tokens": 56}
         )
         call = llm.make_chain(
             client,
@@ -443,13 +445,13 @@ class TestChains(IsolatedAsyncioTestCase):
         def accum(x):
             outputs.append(x)
 
-        completion = await call(dict(animal="duck"), callbacks=[accum])  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"}, callbacks=[accum])  # type: ignore[call-arg]
         assert completion.seconds_to_first_token > 0
         assert completion.prompt_count > 0
         assert completion.completion_count > 0
         assert str(completion) == "".join(outputs)
 
-        completion = await call(dict(animal="duck"))  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"})  # type: ignore[call-arg]
         assert completion.seconds_to_first_token == 0
         assert completion.seconds_to_last_token > 0
 
@@ -457,7 +459,7 @@ class TestChains(IsolatedAsyncioTestCase):
         async def ac(x):
             pass
 
-        completion = await call(dict(animal="duck"), callbacks=[accum, ac])  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"}, callbacks=[accum, ac])  # type: ignore[call-arg]
 
     async def test_anthropic_chain(self):
         try:
@@ -477,13 +479,13 @@ class TestChains(IsolatedAsyncioTestCase):
             outputs.append(x)
 
         outputs: list[str] = []
-        completion = await call(dict(animal="duck"), callbacks=[accum])  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"}, callbacks=[accum])  # type: ignore[call-arg]
         assert completion.seconds_to_first_token > 0
         assert completion.prompt_count > 0
         assert completion.completion_count > 0
         assert str(completion) == "".join(outputs)
 
-        completion = await call(dict(animal="duck"))  # type: ignore[call-arg]
+        completion = await call({"animal": "duck"})  # type: ignore[call-arg]
         assert completion.seconds_to_first_token == 0
         assert completion.seconds_to_last_token > 0
 
@@ -537,11 +539,11 @@ def test_json_evidence():
         r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
         f.write(r.text)
     summary_llm = OpenAILLMModel(
-        config=dict(
-            model="gpt-3.5-turbo-1106",
-            response_format=dict(type="json_object"),
-            temperature=0.0,
-        )
+        config={
+            "model": "gpt-3.5-turbo-1106",
+            "response_format": {"type": "json_object"},
+            "temperature": 0.0,
+        }
     )
     docs = Docs(
         prompts=PromptCollection(json_summary=True),
@@ -570,11 +572,11 @@ def test_custom_json_props():
         r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
         f.write(r.text)
     summary_llm = OpenAILLMModel(
-        config=dict(
-            model="gpt-3.5-turbo-0125",
-            response_format=dict(type="json_object"),
-            temperature=0.0,
-        )
+        config={
+            "model": "gpt-3.5-turbo-0125",
+            "response_format": {"type": "json_object"},
+            "temperature": 0.0,
+        }
     )
     my_prompts = PromptCollection(
         json_summary=True,
@@ -626,7 +628,7 @@ def test_answer_attributes():
     assert len(used_citations) > 0
     assert len(used_citations) < len(answer.contexts)
     assert (
-        answer.get_citation(list(used_citations)[0])
+        answer.get_citation(next(iter(used_citations)))
         == "WikiMedia Foundation, 2023, Accessed now"
     )
 
@@ -652,7 +654,7 @@ def test_llmresult_callbacks():
         dockey="test",
     )
     docs.query("What is Frederick Bates's greatest accomplishment?")
-    assert any([x.name == "answer" for x in my_results])
+    assert any(x.name == "answer" for x in my_results)
     assert len(my_results) > 1
 
 
@@ -1024,7 +1026,7 @@ def test_docs_pickle() -> None:
         f.write(r.text)
         docs = Docs(
             llm_model=OpenAILLMModel(
-                config=dict(temperature=0.0, model="gpt-3.5-turbo")
+                config={"temperature": 0.0, "model": "gpt-3.5-turbo"}
             )
         )
         assert docs._client is not None
@@ -1094,7 +1096,7 @@ def test_repeat_keys():
         r = requests.get("https://en.wikipedia.org/wiki/Frederick_Bates_(politician)")
         f.write(r.text)
     docs = Docs(
-        llm_model=OpenAILLMModel(config=dict(temperature=0.0, model="babbage-002"))
+        llm_model=OpenAILLMModel(config={"temperature": 0.0, "model": "babbage-002"})
     )
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     try:
@@ -1124,7 +1126,7 @@ def test_repeat_keys():
 def test_pdf_reader():
     tests_dir = os.path.dirname(os.path.abspath(__file__))
     doc_path = os.path.join(tests_dir, "paper.pdf")
-    docs = Docs(llm_model=OpenAILLMModel(config=dict(temperature=0.0, model="gpt-4")))
+    docs = Docs(llm_model=OpenAILLMModel(config={"temperature": 0.0, "model": "gpt-4"}))
     docs.add(doc_path, "Wellawatte et al, XAI Review, 2023")  # type: ignore[arg-type]
     answer = docs.query("Are counterfactuals actionable? [yes/no]")
     assert "yes" in answer.answer or "Yes" in answer.answer
@@ -1193,7 +1195,7 @@ def test_code():
     # load this script
     doc_path = os.path.abspath(__file__)
     docs = Docs(
-        llm_model=OpenAILLMModel(config=dict(temperature=0.0, model="babbage-002"))
+        llm_model=OpenAILLMModel(config={"temperature": 0.0, "model": "babbage-002"})
     )
     docs.add(doc_path, "test_paperqa.py", docname="test_paperqa.py", disable_check=True)  # type: ignore[arg-type]
     assert len(docs.docs) == 1
@@ -1208,16 +1210,16 @@ def test_citation():
         f.write(r.text)
     docs = Docs()
     docs.add(doc_path)  # type: ignore[arg-type]
-    assert (
-        list(docs.docs.values())[0].docname == "Wikipedia2024"
-        or list(docs.docs.values())[0].docname == "Frederick2024"
-        or list(docs.docs.values())[0].docname == "Wikipedia"
-        or list(docs.docs.values())[0].docname == "Frederick"
+    assert next(iter(docs.docs.values())).docname in (
+        "Wikipedia2024",
+        "Frederick2024",
+        "Wikipedia",
+        "Frederick",
     )
 
 
 def test_dockey_filter():
-    """Test that we can filter evidence with dockeys"""
+    """Test that we can filter evidence with dockeys."""
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
@@ -1235,7 +1237,7 @@ def test_dockey_filter():
 
 
 def test_dockey_delete():
-    """Test that we can filter evidence with dockeys"""
+    """Test that we can filter evidence with dockeys."""
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
@@ -1252,7 +1254,7 @@ def test_dockey_delete():
     answer = docs.get_evidence(
         answer, max_sources=25, k=30
     )  # we just have a lot so we get both docs
-    keys = set([c.text.doc.dockey for c in answer.contexts])
+    keys = {c.text.doc.dockey for c in answer.contexts}
     assert len(keys) == 2
     assert len(docs.docs) == 2
 
@@ -1264,12 +1266,12 @@ def test_dockey_delete():
     assert len(docs.docs) == 1
     assert len(docs.deleted_dockeys) == 1
     answer = docs.get_evidence(answer, max_sources=25, k=30)
-    keys = set([c.text.doc.dockey for c in answer.contexts])
+    keys = {c.text.doc.dockey for c in answer.contexts}
     assert len(keys) == 1
 
 
 def test_query_filter():
-    """Test that we can filter evidence with in query"""
+    """Test that we can filter evidence with in query."""
     doc_path = "example2.txt"
     with open(doc_path, "w", encoding="utf-8") as f:
         # get wiki page about politician
@@ -1341,7 +1343,7 @@ def test_custom_prompts():
 
 
 def test_pre_prompt():
-    pre = "Provide context you have memorized " "that could help answer '{question}'. "
+    pre = "Provide context you have memorized that could help answer '{question}'. "
 
     docs = Docs(prompts=PromptCollection(pre=pre))
 
@@ -1412,7 +1414,7 @@ def disabled_test_memory():
 
 
 def test_add_texts():
-    llm_config = dict(temperature=0.1, model="babbage-02")
+    llm_config = {"temperature": 0.1, "model": "babbage-02"}
     docs = Docs(llm_model=OpenAILLMModel(config=llm_config))
     docs.add_url(
         "https://en.wikipedia.org/wiki/National_Flag_of_Canada_Day",
@@ -1424,7 +1426,7 @@ def test_add_texts():
     texts = [Text(**dict(t)) for t in docs.texts]
     for t in texts:
         t.embedding = None
-    docs2.add_texts(texts, list(docs.docs.values())[0])
+    docs2.add_texts(texts, next(iter(docs.docs.values())))
 
     for t1, t2 in zip(docs2.texts, docs.texts):
         assert t1.text == t2.text
@@ -1432,7 +1434,7 @@ def test_add_texts():
 
     docs2._build_texts_index()
     # now do it again to test after text index is already built
-    llm_config = dict(temperature=0.1, model="babbage-02")
+    llm_config = {"temperature": 0.1, "model": "babbage-02"}
     docs = Docs(llm_model=OpenAILLMModel(config=llm_config))
     docs.add_url(
         "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)",
@@ -1443,7 +1445,7 @@ def test_add_texts():
     texts = [Text(**dict(t)) for t in docs.texts]
     for t in texts:
         t.embedding = None
-    docs2.add_texts(texts, list(docs.docs.values())[0])
+    docs2.add_texts(texts, next(iter(docs.docs.values())))
     assert len(docs2.docs) == 2
 
     docs2.query("What country was Bates Born in?")


### PR DESCRIPTION
- Upgrades `ruff` and adds config
- Adds `codespell` and `toml-sort` tools, fixing typos
- Deprecates `isort` in favor of `ruff`'s reimplemented `isort`
- Uses `ruff --add-noqa` to get `pre-commit run -a` to pass