### PR TITLE
Vastly reducing chances of flaky `test_docs_pickle`

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1101,9 +1101,8 @@ def test_docs_pickle() -> None:
     assert docs2._client is not None
     assert docs2.llm_model.config == old_config
     assert docs2.summary_llm_model.config == old_sconfig
-    print(old_config, old_sconfig)
     assert len(docs.docs) == len(docs2.docs)
-    for _ in range(4):  # Retry a few times, because this is flaky
+    for _ in range(8):  # Retry multiple times because this is flaky
         docs_context = docs.get_evidence(
             Answer(
                 question="What date is bring your dog to work in the US?",


### PR DESCRIPTION
`test_docs_pickle` is a flaky test:

1. https://github.com/whitead/paper-qa/pull/249 added 4X retrying
2. https://github.com/whitead/paper-qa/pull/250 lowered the threshold similarity

This PR just doubles the retrying count to 8X