### PR TITLE
Support Anyscale OpenAI models

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -207,8 +207,8 @@ class Docs(BaseModel):
         if client is None and isinstance(self.llm_model, OpenAILLMModel):
             # will be defaults if ANYSCALE_BASE_URL and ANYSCALE_API_KEY are not set
             client = AsyncOpenAI(
-                api_key=os.environ.get("ANYSCALE_BASE_URL"),
-                base_url=os.environ.get("ANYSCALE_API_KEY"),
+                api_key=os.environ.get("ANYSCALE_API_KEY"),
+                base_url=os.environ.get("ANYSCALE_BASE_URL"),
             )
         self._client = client
         if embedding_client is None:

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -205,11 +205,15 @@ class Docs(BaseModel):
         embedding_client: Any | None = None,
     ):
         if client is None and isinstance(self.llm_model, OpenAILLMModel):
-            # will be defaults if ANYSCALE_BASE_URL and ANYSCALE_API_KEY are not set
-            client = AsyncOpenAI(
-                api_key=os.environ.get("ANYSCALE_API_KEY"),
-                base_url=os.environ.get("ANYSCALE_BASE_URL"),
-            )
+            if (api_key := os.environ.get("ANYSCALE_API_KEY")) and (
+                base_url := os.environ.get("ANYSCALE_BASE_URL")
+            ):
+                client = AsyncOpenAI(
+                    api_key=api_key,
+                    base_url=base_url,
+                )
+            else:
+                client = AsyncOpenAI()
         self._client = client
         if embedding_client is None:
             # check if we have an openai embedding model in use

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -205,7 +205,11 @@ class Docs(BaseModel):
         embedding_client: Any | None = None,
     ):
         if client is None and isinstance(self.llm_model, OpenAILLMModel):
-            client = AsyncOpenAI()
+            # will be defaults if ANYSCALE_BASE_URL and ANYSCALE_API_KEY are not set
+            client = AsyncOpenAI(
+                api_key=os.environ.get("ANYSCALE_BASE_URL"),
+                base_url=os.environ.get("ANYSCALE_API_KEY"),
+            )
         self._client = client
         if embedding_client is None:
             # check if we have an openai embedding model in use

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -579,7 +579,7 @@ async def test_anyscale_chain():
         "The {animal} says",
         skip_system=True,
     )
-    outputs = []
+    outputs = []  # type: ignore[var-annotated]
     completion = await call({"animal": "duck"}, callbacks=[outputs.append])  # type: ignore[call-arg]
     assert completion.seconds_to_first_token > 0
     assert completion.prompt_count > 0
@@ -590,11 +590,7 @@ async def test_anyscale_chain():
     assert completion.seconds_to_first_token == 0
     assert completion.seconds_to_last_token > 0
 
-    # check with mixed callbacks
-    async def ac(x):  # noqa: ARG001
-        pass
-
-    completion = await call({"animal": "duck"}, callbacks=[accum, ac])  # type: ignore[call-arg]
+    completion = await call({"animal": "duck"}, callbacks=[outputs.append])  # type: ignore[call-arg]
 
 
 def test_docs():

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -571,7 +571,7 @@ async def test_anyscale_chain():
         config={
             "temperature": 0,
             "model": "meta-llama/Meta-Llama-3-8B-Instruct",
-            "max_tokens": 56,
+            "max_tokens": 56,  # matches openAI chat test
         }
     )
     call = llm.make_chain(

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -77,6 +77,8 @@ def test_guess_model_type():
     os.environ["ANYSCALE_BASE_URL"] = "https://example.com"
     assert guess_model_type("meta-llama/Meta-Llama-3-70B-Instruct") == "chat"
     assert guess_model_type("mistralai/Mixtral-8x22B-Instruct-v0.1") == "chat"
+    os.environ.pop("ANYSCALE_API_KEY")
+    os.environ.pop("ANYSCALE_BASE_URL")
 
 
 def test_get_citations():

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -57,6 +57,14 @@ def test_is_openai_model():
     assert not is_openai_model("llama")
     assert not is_openai_model("labgpt")
     assert not is_openai_model("mixtral-7B")
+    os.environ["ANYSCALE_API_KEY"] = "abc123"
+    os.environ["ANYSCALE_BASE_URL"] = "https://example.com"
+    assert is_openai_model("meta-llama/Meta-Llama-3-70B-Instruct")
+    assert is_openai_model("mistralai/Mixtral-8x22B-Instruct-v0.1")
+    os.environ.pop("ANYSCALE_API_KEY")
+    os.environ.pop("ANYSCALE_BASE_URL")
+    assert not is_openai_model("meta-llama/Meta-Llama-3-70B-Instruct")
+    assert not is_openai_model("mistralai/Mixtral-8x22B-Instruct-v0.1")
 
 
 def test_guess_model_type():
@@ -65,6 +73,10 @@ def test_guess_model_type():
     assert guess_model_type("gpt-4-1106-preview") == "chat"
     assert guess_model_type("gpt-3.5-turbo-instruct") == "completion"
     assert guess_model_type("davinci-002") == "completion"
+    os.environ["ANYSCALE_API_KEY"] = "abc123"
+    os.environ["ANYSCALE_BASE_URL"] = "https://example.com"
+    assert guess_model_type("meta-llama/Meta-Llama-3-70B-Instruct") == "chat"
+    assert guess_model_type("mistralai/Mixtral-8x22B-Instruct-v0.1") == "chat"
 
 
 def test_get_citations():


### PR DESCRIPTION
Anyscale supports open source models via a custom base URL in the OpenAI client. This PR enables you to use them in PaperQA by setting the appropriate environment variables and model names. See the docs for Anyscale here: https://docs.anyscale.com/endpoints/text-generation/query-a-model/. 