### PR TITLE
Documented `Context.context` and defaulted `LLMResult.date`

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -639,7 +639,7 @@ class Docs(BaseModel):
             callbacks = get_callbacks("evidence:" + match.name)
             citation = match.doc.citation
             # needed empties for failures/skips
-            llm_result = LLMResult(model="", date="")
+            llm_result = LLMResult(model="")
             extras: dict[str, Any] = {}
             if detailed_citations:
                 citation = match.name + ": " + citation

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import pprint  # noqa: F401
 import re
 import tempfile
 from datetime import datetime

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import os
 import re
 from abc import ABC, abstractmethod
@@ -285,10 +284,7 @@ class LLMModel(ABC, BaseModel):
                 callbacks: list[Callable] | None = None,
             ) -> LLMResult:
                 start_clock = asyncio.get_running_loop().time()
-                result = LLMResult(
-                    model=self.name,
-                    date=datetime.datetime.now().isoformat(),
-                )
+                result = LLMResult(model=self.name)
                 messages = []
                 for m in chat_prompt:
                     messages.append(  # noqa: PERF401
@@ -335,10 +331,7 @@ class LLMModel(ABC, BaseModel):
                 data: dict, callbacks: list[Callable] | None = None
             ) -> LLMResult:
                 start_clock = asyncio.get_running_loop().time()
-                result = LLMResult(
-                    model=self.name,
-                    date=datetime.datetime.now().isoformat(),
-                )
+                result = LLMResult(model=self.name)
                 formatted_prompt = completion_prompt.format(**data)
                 result.prompt_count = self.count_tokens(formatted_prompt)
                 result.prompt = formatted_prompt

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Callable
 from uuid import UUID, uuid4
 
@@ -44,7 +45,7 @@ class LLMResult(BaseModel):
     prompt_count: int = 0
     completion_count: int = 0
     model: str
-    date: str
+    date: str = Field(default_factory=datetime.now().isoformat)
     seconds_to_first_token: float = Field(
         default=0.0, description="Delta time (sec) to first response token's arrival."
     )

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -163,12 +163,10 @@ class PromptCollection(BaseModel):
 class Context(BaseModel):
     """A class to hold the context of a question."""
 
-    context: str
+    context: str = Field(description="Summary of the text with respect to a question.")
     text: Text
     score: int = 5
-    model_config = ConfigDict(
-        extra="allow",
-    )
+    model_config = ConfigDict(extra="allow")
 
 
 def __str__(self) -> str:  # noqa: N807


### PR DESCRIPTION
- Defaulted `LLMResult.date` for convenience
- Documented `Context.context`
- Removed unused `pprint` import