### PR TITLE
Moved to `setuptools_scm` for versioning from `git tag`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 *.ipynb
 env
+
+# Matching pyproject.toml
+paperqa/version.py

--- a/paperqa/version.py
+++ b/paperqa/version.py
@@ -1,5 +1,0 @@
-from importlib.metadata import version
-
-# If you're looking to bump the version, this now
-# lives in the pyproject.toml's [project] section
-__version__ = version("paper-qa")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-# Pin to 62.6 for support from reading requirements from requirements.txt
-requires = ["setuptools >= 62.6.0"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 
 [project]
 authors = [
@@ -29,7 +28,7 @@ dependencies = [
     "tiktoken>=0.4.0",
 ]
 description = "LLM Chain for answering questions from docs"
-dynamic = ["optional-dependencies"]
+dynamic = ["optional-dependencies", "version"]
 keywords = ["question answering"]
 license = {file = "LICENSE"}
 maintainers = [
@@ -40,7 +39,6 @@ name = "paper-qa"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {repository = "https://github.com/whitead/paper-qa"}
-version = "4.8.1"
 
 [tool.codespell]
 check-filenames = true
@@ -221,6 +219,9 @@ file = ["dev-requirements.txt"]
 
 [tool.setuptools.packages.find]
 include = ["paperqa*"]
+
+[tool.setuptools_scm]
+version_file = "paperqa/version.py"
 
 [tool.tomlsort]
 all = true


### PR DESCRIPTION
This PR moves us to use [pypa/setuptools_scm](https://github.com/pypa/setuptools_scm) for version management, and creation of a version.py file