### PR TITLE
Updated readme and models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ env
 
 # Matching pyproject.toml
 paperqa/version.py
+tests/example*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,5 +60,3 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies:
-          - black==22.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         additional_dependencies:
           - "validate-pyproject-schema-store[all]>=2024.06.24" # Pin for Ruff's FURB154
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "v1.12.1"
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
       - id: validate-pyproject
         additional_dependencies:
           - "validate-pyproject-schema-store[all]>=2024.06.24" # Pin for Ruff's FURB154
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "v1.12.1"
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+          - black==22.12.0

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ from anthropic import AsyncAnthropic
 docs = Docs(llm='claude-3-5-sonnet-20240620',
             summary_llm='claude-3-5-sonnet-20240620',
             client=AsyncAnthropic())
-
 ```
 
 Or you can use any other model available in [langchain](https://github.com/hwchase17/langchain):
@@ -171,7 +170,8 @@ local_client = AsyncOpenAI(
 docs = Docs(client=local_client,
             docs_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
             texts_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
-            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)))
+            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)),
+        )
 ```
 
 ### Changing Embedding Model
@@ -182,7 +182,6 @@ paper-qa defaults to using OpenAI (`text-embedding-3-small`) embeddings, but has
 from paperqa import Docs
 
 docs = Docs(embedding="text-embedding-3-large")
-
 ```
 
 `embedding` accepts:
@@ -199,8 +198,8 @@ For deeper embedding customization, embedding models and vector stores can be bu
 from paperqa import Docs, NumpyVectorStore, OpenAIEmbeddingModel
 
 docs = Docs(docs_index=NumpyVectorStore(embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")),
-            texts_index=NumpyVectorStore(embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")))
-
+            texts_index=NumpyVectorStore(embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")),
+        )
 ```
 
 Note that embedding models are specified as attributes of paper-qa's `VectorStore` base class. `NumpyVectorStore` is the best place to start, it's a simple in-memory store, without an index. If a larger-than-memory vector store is needed, you can use the `LangchainVectorStore` like this:
@@ -212,9 +211,8 @@ from paperqa import Docs, LangchainVectorStore
 
 docs = Docs(
         docs_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
-        texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings())
+        texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
     )
-
 ```
 
 We support both local langchain embedding models and the [SentenceTransformer](https://www.sbert.net/) models. For example:
@@ -233,7 +231,8 @@ local_client = AsyncOpenAI(
 docs = Docs(client=local_client,
             docs_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
             texts_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
-            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)))
+            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)),
+        )
 ```
 
 We also support hybrid keyword (sparse token modulo vectors) and dense embedding vectors. They can be specified as follows:
@@ -247,7 +246,7 @@ model = HybridEmbeddingModel(
 docs = Docs(
     docs_index=NumpyVectorStore(embedding_model=model),
     texts_index=NumpyVectorStore(embedding_model=model),
-)
+    )
 ```
 
 The sparse embedding (keyword) models default to having 256 dimensions, but this can be specified via the `ndim` argument.

--- a/README.md
+++ b/README.md
@@ -63,16 +63,17 @@ You need to have an LLM to use paper-qa. You can use OpenAI, llama.cpp (via Serv
 To use paper-qa, you need to have a list of paths/files/urls (valid extensions include: .pdf, .txt). You can then use the `Docs` class to add the documents and then query them. `Docs` will try to guess citation formats from the content of the files, but you can also provide them yourself.
 
 ```python
-
 from paperqa import Docs
 
-my_docs = ...# get a list of paths
+my_docs = ...  # get a list of paths
 
 docs = Docs()
 for d in my_docs:
     docs.add(d)
 
-answer = docs.query("What manufacturing challenges are unique to bispecific antibodies?")
+answer = docs.query(
+    "What manufacturing challenges are unique to bispecific antibodies?"
+)
 print(answer.formatted_answer)
 ```
 
@@ -92,16 +93,18 @@ paper-qa is written to be used asynchronously. The synchronous API is just a wra
 
 The synchronous version just call the async version in a loop. Most modern python environments support async natively (including Jupyter notebooks!). So you can do this in a Jupyter Notebook:
 
-```py
+```python
 from paperqa import Docs
 
-my_docs = ...# get a list of paths
+my_docs = ...  # get a list of paths
 
 docs = Docs()
 for d in my_docs:
     await docs.aadd(d)
 
-answer = await docs.aquery("What manufacturing challenges are unique to bispecific antibodies?")
+answer = await docs.aquery(
+    "What manufacturing challenges are unique to bispecific antibodies?"
+)
 ```
 
 ### Adding Documents
@@ -112,36 +115,38 @@ answer = await docs.aquery("What manufacturing challenges are unique to bispecif
 
 By default, it uses OpenAI models with a hybrid of `gpt-4o-mini` (for the re-ranking and summary step, `summary_llm` argument) and `gpt-4-turbo` (for the answering step, `llm` argument). You can adjust this:
 
-```py
-docs = Docs(llm='gpt-4o-mini', summary_llm='gpt-4o')
+```python
+docs = Docs(llm="gpt-4o-mini", summary_llm="gpt-4o")
 ```
 
 You can use Anthropic models by specifying an Anthropic client:
 
-```py
+```python
 from paperqa import Docs
 from anthropic import AsyncAnthropic
 
-docs = Docs(llm='claude-3-5-sonnet-20240620',
-            summary_llm='claude-3-5-sonnet-20240620',
-            client=AsyncAnthropic())
+docs = Docs(
+    llm="claude-3-5-sonnet-20240620",
+    summary_llm="claude-3-5-sonnet-20240620",
+    client=AsyncAnthropic(),
+)
 ```
 
 Or you can use any other model available in [langchain](https://github.com/hwchase17/langchain):
 
-```py
+```python
 from paperqa import Docs
 from langchain_community.chat_models import ChatAnthropic
-docs = Docs(llm="langchain",
-            client=ChatAnthropic())
+
+docs = Docs(llm="langchain", client=ChatAnthropic())
 ```
 
 Note we split the model into the wrapper and `client`, which is `ChatAnthropic` here. This is because `client` stores the non-pickleable part and langchain LLMs are only sometimes serializable/pickleable. The paper-qa `Docs` must always serializable. Thus, we split the model into two parts.
 
-```py
+```python
 import pickle
-docs = Docs(llm="langchain",
-            client=ChatAnthropic())
+
+docs = Docs(llm="langchain", client=ChatAnthropic())
 model_str = pickle.dumps(docs)
 docs = pickle.loads(model_str)
 # but you have to set the client after loading
@@ -156,29 +161,33 @@ You can use llama.cpp to be the LLM. Note that you should be using relatively la
 
 The easiest way to get set-up is to download a [llama file](https://github.com/Mozilla-Ocho/llamafile) and execute it with `-cb -np 4 -a my-llm-model --embedding` which will enable continuous batching and embeddings.
 
-```py
+```python
 from paperqa import Docs, LlamaEmbeddingModel
 from openai import AsyncOpenAI
 
 # start llamap.cpp client with
 
 local_client = AsyncOpenAI(
-    base_url="http://localhost:8080/v1",
-    api_key = "sk-no-key-required"
+    base_url="http://localhost:8080/v1", api_key="sk-no-key-required"
 )
 
-docs = Docs(client=local_client,
-            docs_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
-            texts_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
-            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)),
+docs = Docs(
+    client=local_client,
+    docs_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
+    texts_index=NumpyVectorStore(embedding_model=LlamaEmbeddingModel()),
+    llm_model=OpenAILLMModel(
+        config=dict(
+            model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512
         )
+    ),
+)
 ```
 
 ### Changing Embedding Model
 
 paper-qa defaults to using OpenAI (`text-embedding-3-small`) embeddings, but has flexible options for both vector stores and embedding choices. The simplest way to change an embedding is via the `embedding` argument to the `Docs` object constructor:
 
-```py
+```python
 from paperqa import Docs
 
 docs = Docs(embedding="text-embedding-3-large")
@@ -194,59 +203,66 @@ docs = Docs(embedding="text-embedding-3-large")
 
 For deeper embedding customization, embedding models and vector stores can be built separately and passed into the `Docs` object. Embedding models are used to create both paper-qa's index of document citation embedding vectors (`docs_index` argument) as well as the full-text embedding vectors (`texts_index` argument). They can both be specified as arguments when you create a new `Docs` object. You can use use any embedding model which implements paper-qa's `EmbeddingModel` class. For example, to use `text-embedding-3-large`:
 
-```py
+```python
 from paperqa import Docs, NumpyVectorStore, OpenAIEmbeddingModel
 
-docs = Docs(docs_index=NumpyVectorStore(embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")),
-            texts_index=NumpyVectorStore(embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")),
-        )
+docs = Docs(
+    docs_index=NumpyVectorStore(
+        embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")
+    ),
+    texts_index=NumpyVectorStore(
+        embedding_model=OpenAIEmbeddingModel(name="text-embedding-3-large")
+    ),
+)
 ```
 
 Note that embedding models are specified as attributes of paper-qa's `VectorStore` base class. `NumpyVectorStore` is the best place to start, it's a simple in-memory store, without an index. If a larger-than-memory vector store is needed, you can use the `LangchainVectorStore` like this:
 
-```py
+```python
 from langchain_community.vectorstores.faiss import FAISS
 from langchain_openai import OpenAIEmbeddings
 from paperqa import Docs, LangchainVectorStore
 
 docs = Docs(
-        docs_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
-        texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
-    )
+    docs_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
+    texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
+)
 ```
 
 We support both local langchain embedding models and the [SentenceTransformer](https://www.sbert.net/) models. For example:
 
-```py
+```python
 from paperqa import Docs, SentenceTransformerEmbeddingModel
 from openai import AsyncOpenAI
 
 # start llamap.cpp client with
 
 local_client = AsyncOpenAI(
-    base_url="http://localhost:8080/v1",
-    api_key = "sk-no-key-required"
+    base_url="http://localhost:8080/v1", api_key="sk-no-key-required"
 )
 
-docs = Docs(client=local_client,
-            docs_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
-            texts_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
-            llm_model=OpenAILLMModel(config=dict(model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512)),
+docs = Docs(
+    client=local_client,
+    docs_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
+    texts_index=NumpyVectorStore(embedding_model=SentenceTransformerEmbeddingModel()),
+    llm_model=OpenAILLMModel(
+        config=dict(
+            model="my-llm-model", temperature=0.1, frequency_penalty=1.5, max_tokens=512
         )
+    ),
+)
 ```
 
 We also support hybrid keyword (sparse token modulo vectors) and dense embedding vectors. They can be specified as follows:
 
-```py
+```python
 from paperqa import Docs, HybridEmbeddingModel, SparseEmbeddingModel, NumpyVectorStore
 
-model = HybridEmbeddingModel(
-        models=[OpenAIEmbeddingModel(), SparseEmbeddingModel()]
-    )
+model = HybridEmbeddingModel(models=[OpenAIEmbeddingModel(), SparseEmbeddingModel()])
 docs = Docs(
     docs_index=NumpyVectorStore(embedding_model=model),
     texts_index=NumpyVectorStore(embedding_model=model),
-    )
+)
 ```
 
 The sparse embedding (keyword) models default to having 256 dimensions, but this can be specified via the `ndim` argument.
@@ -255,8 +271,12 @@ The sparse embedding (keyword) models default to having 256 dimensions, but this
 
 You can adjust the numbers of sources (passages of text) to reduce token usage or add more context. `k` refers to the top k most relevant and diverse (may from different sources) passages. Each passage is sent to the LLM to summarize, or determine if it is irrelevant. After this step, a limit of `max_sources` is applied so that the final answer can fit into the LLM context window. Thus, `k` > `max_sources` and `max_sources` is the number of sources used in the final answer.
 
-```py
-docs.query("What manufacturing challenges are unique to bispecific antibodies?", k = 5, max_sources = 2)
+```python
+docs.query(
+    "What manufacturing challenges are unique to bispecific antibodies?",
+    k=5,
+    max_sources=2,
+)
 ```
 
 ### Using Code or HTML
@@ -264,15 +284,14 @@ docs.query("What manufacturing challenges are unique to bispecific antibodies?",
 You do not need to use papers -- you can use code or raw HTML. Note that this tool is focused on answering questions, so it won't do well at writing code. One note is that the tool cannot infer citations from code, so you will need to provide them yourself.
 
 ```python
-
 import glob
 
-source_files = glob.glob('**/*.js')
+source_files = glob.glob("**/*.js")
 
 docs = Docs()
 for f in source_files:
     # this assumes the file names are unique in code
-    docs.add(f, citation='File ' + os.path.name(f), docname=os.path.name(f))
+    docs.add(f, citation="File " + os.path.name(f), docname=os.path.name(f))
 answer = docs.query("Where is the search bar in the header defined?")
 print(answer)
 ```
@@ -281,26 +300,26 @@ print(answer)
 
 You may want to cache parsed texts and embeddings in an external database or file. You can then build a Docs object from those directly:
 
-```py
-
+```python
 docs = Docs()
 
 for ... in my_docs:
-    doc = Doc(docname=...,  citation=..., dockey=..., citation=...)
+    doc = Doc(docname=..., citation=..., dockey=..., citation=...)
     texts = [Text(text=..., name=..., doc=doc) for ... in my_texts]
     docs.add_texts(texts, doc)
 ```
 
 If you want to use an external vector store, you can also do that directly via langchain. For example, to use the [FAISS](https://ai.meta.com/tools/faiss/) vector store from langchain:
 
-```py
+```python
 from paperqa import LangchainVectorStore, Docs
 from langchain_community.vector_store import FAISS
 from langchain_openai import OpenAIEmbeddings
 
-docs = Docs(texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
-            docs_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()))
-
+docs = Docs(
+    texts_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
+    docs_index=LangchainVectorStore(cls=FAISS, embedding_model=OpenAIEmbeddings()),
+)
 ```
 
 ## Where do I get papers?
@@ -335,7 +354,7 @@ To download papers, you need to get an API key for your account.
 
 With this, we can download papers from our library and add them to `paperqa`:
 
-```py
+```python
 from paperqa.contrib import ZoteroDB
 
 docs = paperqa.Docs()
@@ -352,13 +371,13 @@ them to the `Docs` object.
 
 We can also do specific queries of our Zotero library and iterate over the results:
 
-```py
+```python
 for item in zotero.iterate(
-        q="large language models",
-        qmode="everything",
-        sort="date",
-        direction="desc",
-        limit=100,
+    q="large language models",
+    qmode="everything",
+    sort="date",
+    direction="desc",
+    limit=100,
 ):
     print("Adding", item.title)
     docs.add(item.pdf, docname=item.key)
@@ -371,17 +390,19 @@ You can read more about the search syntax by typing `zotero.iterate?` in IPython
 If you want to search for papers outside of your own collection, I've found an unrelated project called [paper-scraper](https://github.com/blackadad/paper-scraper) that looks
 like it might help. But beware, this project looks like it uses some scraping tools that may violate publisher's rights or be in a gray area of legality.
 
-```py
-keyword_search = 'bispecific antibody manufacture'
+```python
+keyword_search = "bispecific antibody manufacture"
 papers = paperscraper.search_papers(keyword_search)
 docs = paperqa.Docs()
-for path,data in papers.items():
+for path, data in papers.items():
     try:
         docs.add(path)
     except ValueError as e:
         # sometimes this happens if PDFs aren't downloaded or readable
-        print('Could not read', path, e)
-answer = docs.query("What manufacturing challenges are unique to bispecific antibodies?")
+        print("Could not read", path, e)
+answer = docs.query(
+    "What manufacturing challenges are unique to bispecific antibodies?"
+)
 print(answer)
 ```
 
@@ -401,9 +422,15 @@ To execute a function on each chunk of LLM completions, you need to provide a fu
 def make_typewriter(step_name):
     def typewriter(chunk):
         print(chunk, end="")
-    return [typewriter] # <- note that this is a list of functions
+
+    return [typewriter]  # <- note that this is a list of functions
+
+
 ...
-docs.query("What manufacturing challenges are unique to bispecific antibodies?", get_callbacks=make_typewriter)
+docs.query(
+    "What manufacturing challenges are unique to bispecific antibodies?",
+    get_callbacks=make_typewriter,
+)
 ```
 
 ### Caching Embeddings
@@ -417,14 +444,16 @@ You can customize any of the prompts, using the `PromptCollection` class. For ex
 ```python
 from paperqa import Docs, Answer, PromptCollection
 
-my_qaprompt = "Answer the question '{question}' "
+my_qaprompt = (
+    "Answer the question '{question}' "
     "Use the context below if helpful. "
     "You can cite the context using the key "
     "like (Example2012). "
     "If there is insufficient context, write a poem "
     "about how you cannot answer.\n\n"
     "Context: {context}\n\n"
-prompts=PromptCollection(qa=my_qaprompt)
+)
+prompts = PromptCollection(qa=my_qaprompt)
 docs = Docs(prompts=prompts)
 ```
 
@@ -458,5 +487,5 @@ with open("my_docs.pkl", "wb") as f:
 with open("my_docs.pkl", "rb") as f:
     docs = pickle.load(f)
 
-docs.set_client() #defaults to OpenAI
+docs.set_client()  # defaults to OpenAI
 ```

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -146,7 +146,7 @@ class Docs(BaseModel):
                 and isinstance(data.llm_model, OpenAILLMModel)
             ):
                 data.summary_llm_model = OpenAILLMModel(
-                    config={"model": "gpt-3.5-turbo", "temperature": 0.1}
+                    config={"model": "gpt-4o-mini", "temperature": 0.1}
                 )
             elif data.summary_llm_model is None:
                 data.summary_llm_model = data.llm_model

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -155,7 +155,7 @@ class EmbeddingModel(ABC, BaseModel):
 
 
 class OpenAIEmbeddingModel(EmbeddingModel):
-    name: str = Field(default="text-embedding-ada-002")
+    name: str = Field(default="text-embedding-3-small")
 
     async def embed_documents(self, client: Any, texts: list[str]) -> list[list[float]]:
         return await embed_documents(cast(AsyncOpenAI, client), texts, self.name)
@@ -376,8 +376,8 @@ class LLMModel(ABC, BaseModel):
 
 
 class OpenAILLMModel(LLMModel):
-    config: dict = Field(default={"model": "gpt-3.5-turbo", "temperature": 0.1})
-    name: str = "gpt-3.5-turbo"
+    config: dict = Field(default={"model": "gpt-4o-mini", "temperature": 0.1})
+    name: str = "gpt-4o-mini"
 
     def _check_client(self, client: Any) -> AsyncOpenAI:
         if client is None:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -52,7 +52,7 @@ from paperqa.utils import (
 
 
 def test_is_openai_model():
-    assert is_openai_model("gpt-3.5-turbo")
+    assert is_openai_model("gpt-4o-mini")
     assert is_openai_model("babbage-002")
     assert is_openai_model("gpt-4-1106-preview")
     assert is_openai_model("davinci-002")
@@ -506,7 +506,7 @@ async def test_chain_completion():
 async def test_chain_chat():
     client = AsyncOpenAI()
     llm = OpenAILLMModel(
-        config={"temperature": 0, "model": "gpt-3.5-turbo", "max_tokens": 56}
+        config={"temperature": 0, "model": "gpt-4o-mini", "max_tokens": 56}
     )
     call = llm.make_chain(
         client,
@@ -668,7 +668,7 @@ def test_json_evidence() -> None:
         f.write(r.text)
     summary_llm = OpenAILLMModel(
         config={
-            "model": "gpt-3.5-turbo-1106",
+            "model": "gpt-4o-mini",
             "response_format": {"type": "json_object"},
             "temperature": 0.0,
         }
@@ -702,7 +702,7 @@ def test_custom_json_props():
         f.write(r.text)
     summary_llm = OpenAILLMModel(
         config={
-            "model": "gpt-3.5-turbo-0125",
+            "model": "gpt-4o-mini",
             "response_format": {"type": "json_object"},
             "temperature": 0.0,
         }
@@ -979,11 +979,11 @@ def test_custom_llm_stream():
 def test_langchain_llm():
     from langchain_openai import ChatOpenAI, OpenAI
 
-    docs = Docs(llm="langchain", client=ChatOpenAI(model="gpt-3.5-turbo"))
+    docs = Docs(llm="langchain", client=ChatOpenAI(model="gpt-4o-mini"))
     assert isinstance(docs.llm_model, LangchainLLMModel)
     assert isinstance(docs.summary_llm_model, LangchainLLMModel)
-    assert docs.llm == "gpt-3.5-turbo"
-    assert docs.summary_llm == "gpt-3.5-turbo"
+    assert docs.llm == "gpt-4o-mini"
+    assert docs.summary_llm == "gpt-4o-mini"
     docs.add_url(
         "https://en.wikipedia.org/wiki/Frederick_Bates_(politician)",
         citation="WikiMedia Foundation, 2023, Accessed now",
@@ -1209,10 +1209,10 @@ def test_docs_pickle() -> None:
         f.write(r.text)
         docs = Docs(
             llm_model=OpenAILLMModel(
-                config={"temperature": 0.0, "model": "gpt-3.5-turbo"}
+                config={"temperature": 0.0, "model": "gpt-4o-mini"}
             ),
             summary_llm_model=OpenAILLMModel(
-                config={"temperature": 0.0, "model": "gpt-3.5-turbo"}
+                config={"temperature": 0.0, "model": "gpt-4o-mini"}
             ),
         )
         assert docs._client is not None
@@ -1595,7 +1595,7 @@ def test_too_much_evidence():
         # get wiki page about politician
         r = requests.get("https://en.wikipedia.org/wiki/Barack_Obama")  # noqa: S113
         f.write(r.text)
-    docs = Docs(llm="gpt-3.5-turbo", summary_llm="gpt-3.5-turbo")
+    docs = Docs(llm="gpt-4o-mini", summary_llm="gpt-4o-mini")
     docs.add(doc_path, "WikiMedia Foundation, 2023, Accessed now")  # type: ignore[arg-type]
     # add with new dockey
     with open("example.txt", "w", encoding="utf-8") as f:
@@ -1780,8 +1780,8 @@ def test_external_doc_index():
 
 def test_embedding_name_consistency():
     docs = Docs()
-    assert docs.embedding == "text-embedding-ada-002"
-    assert docs.texts_index.embedding_model.name == "text-embedding-ada-002"
+    assert docs.embedding == "text-embedding-3-small"
+    assert docs.texts_index.embedding_model.name == "text-embedding-3-small"
     docs = Docs(embedding="langchain")
     assert docs.embedding == "langchain"
     assert docs.texts_index.embedding_model.name == "langchain"
@@ -1794,9 +1794,9 @@ def test_embedding_name_consistency():
     )
     assert docs.embedding == "test"
 
-    docs = Docs(embedding="hybrid-text-embedding-ada-002")
+    docs = Docs(embedding="hybrid-text-embedding-3-small")
     assert isinstance(docs.docs_index.embedding_model, HybridEmbeddingModel)
-    assert docs.docs_index.embedding_model.models[0].name == "text-embedding-ada-002"
+    assert docs.docs_index.embedding_model.models[0].name == "text-embedding-3-small"
     assert docs.docs_index.embedding_model.models[1].name == "sparse"
 
 


### PR DESCRIPTION
[maspotts](https://github.com/maspotts) pointed out that our Readme is out of sync with the usage in our tests.  (#304 )

This PR updates the readme to help make users aware of the correct `Docs` usage for custom embedding models. It also changes some of the default models to better OpenAI choices given the updates in the last few months. 